### PR TITLE
Adjust Cluster discovery logging

### DIFF
--- a/grakn/cluster/client.py
+++ b/grakn/cluster/client.py
@@ -44,8 +44,8 @@ class _ClusterClient(GraknClusterClient):
     def _fetch_server_addresses(self, addresses: Iterable[str]) -> Set[str]:
         for address in addresses:
             try:
+                print("Fetching list of cluster servers from %s..." % address)
                 with _CoreClient(address) as client:
-                    print("Fetching list of cluster servers from %s..." % address)
                     grakn_cluster_stub = GraknClusterStub(client.channel())
                     res = grakn_cluster_stub.servers_all(cluster_server_manager_all_req())
                     members = {srv.address for srv in res.servers}


### PR DESCRIPTION
## What is the goal of this PR?

Print logs on cluster discovery _before_ the actual discovery happens (and has a chance to fail) such that passing invalid cluster address is easier to debug.

## What are the changes implemented in this PR?

Print "Performing cluster discovery to ..." message before attempting to do actual discovery.