### PR TITLE
Add concept cast methods, and add all Concept types to typedb.client

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "25e45df9512604812f800218066b0f93435e44d2"
+        commit = "8059e3aadaa46de8de0ccf57580dd0a3a61d06a4"
     )

--- a/tests/behaviour/background/cluster/environment.py
+++ b/tests/behaviour/background/cluster/environment.py
@@ -20,8 +20,7 @@
 #
 import os
 
-from typedb.api.connection.credential import TypeDBCredential
-from typedb.client import TypeDB
+from typedb.client import *
 from tests.behaviour.background import environment_base
 from tests.behaviour.context import Context
 

--- a/tests/behaviour/background/core/environment.py
+++ b/tests/behaviour/background/core/environment.py
@@ -20,7 +20,7 @@
 #
 
 from tests.behaviour.background import environment_base
-from typedb.client import TypeDB
+from typedb.client import *
 from tests.behaviour.context import Context
 
 

--- a/tests/behaviour/background/environment_base.py
+++ b/tests/behaviour/background/environment_base.py
@@ -18,11 +18,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from behave import *
 from behave.model_core import Status
 
+from typedb.client import *
+
 from tests.behaviour.config.parameters import RootLabel
-from tests.behaviour.context import Context, ThingSubtype
+from tests.behaviour.context import Context
 
 import time
 
@@ -47,7 +48,7 @@ def before_scenario(context: Context, scenario):
     context.clear_answers = lambda: _clear_answers_impl(context)
 
 
-def _put_impl(context: Context, variable: str, thing: ThingSubtype):
+def _put_impl(context: Context, variable: str, thing: Thing):
     context.things[variable] = thing
 
 

--- a/tests/behaviour/concept/thing/attribute/attribute_steps.py
+++ b/tests/behaviour/concept/thing/attribute/attribute_steps.py
@@ -23,8 +23,7 @@ from datetime import datetime
 from behave import *
 from hamcrest import *
 
-from typedb.api.concept.type.attribute_type import AttributeType
-from typedb.common.exception import TypeDBClientException
+from typedb.client import *
 from tests.behaviour.context import Context
 
 
@@ -40,17 +39,17 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute {var1:Var} get owners contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var2), is_in(context.get(var1).as_remote(context.tx()).get_owners()))
+    assert_that(context.get(var2), is_in(context.get(var1).as_attribute().as_remote(context.tx()).get_owners()))
 
 
 @step("attribute {var1:Var} get owners do not contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var2), not_(is_in(context.get(var1).as_remote(context.tx()).get_owners())))
+    assert_that(context.get(var2), not_(is_in(context.get(var1).as_attribute().as_remote(context.tx()).get_owners())))
 
 
 @step("attribute {var:Var} has value type: {value_type:ValueType}")
 def step_impl(context: Context, var: str, value_type: AttributeType.ValueType):
-    assert_that(context.get(var).get_type().get_value_type(), is_(value_type))
+    assert_that(context.get(var).as_attribute().get_type().get_value_type(), is_(value_type))
 
 
 @step("attribute({type_label}) as(boolean) put: {value:Bool}; throws exception")
@@ -130,24 +129,24 @@ def step_impl(context: Context, var: str, type_label: str, value: datetime):
 
 @step("attribute {var:Var} has boolean value: {value:Bool}")
 def step_impl(context: Context, var: str, value: bool):
-    assert_that(context.get(var).get_value(), is_(value))
+    assert_that(context.get(var).as_attribute().get_value(), is_(value))
 
 
 @step("attribute {var:Var} has long value: {value:Int}")
 def step_impl(context: Context, var: str, value: int):
-    assert_that(context.get(var).get_value(), is_(value))
+    assert_that(context.get(var).as_attribute().get_value(), is_(value))
 
 
 @step("attribute {var:Var} has double value: {value:Float}")
 def step_impl(context: Context, var: str, value: float):
-    assert_that(context.get(var).get_value(), is_(value))
+    assert_that(context.get(var).as_attribute().get_value(), is_(value))
 
 
 @step("attribute {var:Var} has string value: {value}")
 def step_impl(context: Context, var: str, value: str):
-    assert_that(context.get(var).get_value(), is_(value))
+    assert_that(context.get(var).as_attribute().get_value(), is_(value))
 
 
 @step("attribute {var:Var} has datetime value: {value:DateTime}")
 def step_impl(context: Context, var: str, value: datetime):
-    assert_that(context.get(var).get_value(), is_(value))
+    assert_that(context.get(var).as_attribute().get_value(), is_(value))

--- a/tests/behaviour/concept/thing/entity/entity_steps.py
+++ b/tests/behaviour/concept/thing/entity/entity_steps.py
@@ -22,8 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from typedb.common.exception import TypeDBClientException
-from typedb.common.label import Label
+from typedb.client import *
 from tests.behaviour.context import Context
 
 

--- a/tests/behaviour/concept/thing/thing_steps.py
+++ b/tests/behaviour/concept/thing/thing_steps.py
@@ -22,8 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from typedb.common.exception import TypeDBClientException
-from typedb.common.label import Label
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, RootLabel
 from tests.behaviour.context import Context
 
@@ -62,7 +61,7 @@ def step_impl(context: Context, var: str):
 @step("relation {var1:Var} set has: {var2:Var}; throws exception")
 def step_impl(context: Context, var1: str, var2: str):
     try:
-        context.get(var1).as_remote(context.tx()).set_has(context.get(var2))
+        context.get(var1).as_remote(context.tx()).set_has(context.get(var2).as_attribute())
         assert False
     except TypeDBClientException:
         pass
@@ -72,35 +71,35 @@ def step_impl(context: Context, var1: str, var2: str):
 @step("attribute {var1:Var} set has: {var2:Var}")
 @step("relation {var1:Var} set has: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    context.get(var1).as_remote(context.tx()).set_has(context.get(var2))
+    context.get(var1).as_remote(context.tx()).set_has(context.get(var2).as_attribute())
 
 
 @step("entity {var1:Var} unset has: {var2:Var}")
 @step("attribute {var1:Var} unset has: {var2:Var}")
 @step("relation {var1:Var} unset has: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    context.get(var1).as_remote(context.tx()).unset_has(context.get(var2))
+    context.get(var1).as_remote(context.tx()).unset_has(context.get(var2).as_attribute())
 
 
 @step("entity {var1:Var} get keys contain: {var2:Var}")
 @step("attribute {var1:Var} get keys contain: {var2:Var}")
 @step("relation {var1:Var} get keys contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(only_key=True), has_item(context.get(var2)))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(only_key=True), has_item(context.get(var2).as_attribute()))
 
 
 @step("entity {var1:Var} get keys do not contain: {var2:Var}")
 @step("attribute {var1:Var} get keys do not contain: {var2:Var}")
 @step("relation {var1:Var} get keys do not contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(only_key=True), not_(has_item(context.get(var2))))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(only_key=True), not_(has_item(context.get(var2).as_attribute())))
 
 
 @step("entity {var1:Var} get attributes contain: {var2:Var}")
 @step("attribute {var1:Var} get attributes contain: {var2:Var}")
 @step("relation {var1:Var} get attributes contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(), has_item(context.get(var2)))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(), has_item(context.get(var2).as_attribute()))
 
 
 @step("entity {var1:Var} get attributes({type_label}) contain: {var2:Var}")
@@ -122,14 +121,14 @@ def step_impl(context: Context, var1: str, var2: str):
 @step("attribute {var1:Var} get attributes({type_label}) as(datetime) contain: {var2:Var}")
 @step("relation {var1:Var} get attributes({type_label}) as(datetime) contain: {var2:Var}")
 def step_impl(context: Context, var1: str, type_label: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(attribute_type=context.tx().concepts().get_attribute_type(type_label)), has_item(context.get(var2)))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(attribute_type=context.tx().concepts().get_attribute_type(type_label)), has_item(context.get(var2).as_attribute()))
 
 
 @step("entity {var1:Var} get attributes do not contain: {var2:Var}")
 @step("attribute {var1:Var} get attributes do not contain: {var2:Var}")
 @step("relation {var1:Var} get attributes do not contain: {var2:Var}")
 def step_impl(context: Context, var1: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(), not_(has_item(context.get(var2))))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(), not_(has_item(context.get(var2).as_attribute())))
 
 
 @step("entity {var1:Var} get attributes({type_label}) do not contain: {var2:Var}")
@@ -151,7 +150,8 @@ def step_impl(context: Context, var1: str, var2: str):
 @step("attribute {var1:Var} get attributes({type_label}) as(datetime) do not contain: {var2:Var}")
 @step("relation {var1:Var} get attributes({type_label}) as(datetime) do not contain: {var2:Var}")
 def step_impl(context: Context, var1: str, type_label: str, var2: str):
-    assert_that(context.get(var1).as_remote(context.tx()).get_has(attribute_type=context.tx().concepts().get_attribute_type(type_label)), not_(has_item(context.get(var2))))
+    assert_that(context.get(var1).as_remote(context.tx()).get_has(attribute_type=context.tx().concepts().get_attribute_type(type_label)),
+                not_(has_item(context.get(var2).as_attribute())))
 
 
 @step("entity {var1:Var} get relations({label:ScopedLabel}) contain: {var2:Var}")

--- a/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
+++ b/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
@@ -22,7 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from typedb.api.concept.type.attribute_type import AttributeType
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_value_type, parse_list, parse_label
 from tests.behaviour.context import Context
 
@@ -39,7 +39,7 @@ def step_impl(context: Context, type_label: str, value_type: str):
 
 @step("attribute({type_label}) get supertype value type: {value_type}")
 def step_impl(context: Context, type_label: str, value_type: str):
-    supertype = context.tx().concepts().get_attribute_type(type_label).as_remote(context.tx()).get_supertype()
+    supertype = context.tx().concepts().get_attribute_type(type_label).as_remote(context.tx()).get_supertype().as_attribute_type()
     assert_that(supertype.get_value_type(), is_(parse_value_type(value_type)))
 
 

--- a/tests/behaviour/concept/type/relationtype/relation_type_steps.py
+++ b/tests/behaviour/concept/type/relationtype/relation_type_steps.py
@@ -22,8 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from typedb.common.exception import TypeDBClientException
-from typedb.common.label import Label
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_list, parse_bool, parse_label
 from tests.behaviour.context import Context
 

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -22,8 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from typedb.common.exception import TypeDBClientException
-from typedb.common.label import Label
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_label
 from tests.behaviour.context import Context
 

--- a/tests/behaviour/config/parameters.py
+++ b/tests/behaviour/config/parameters.py
@@ -27,9 +27,7 @@ from behave import register_type
 from behave.model import Table
 
 # TODO: We aren't consistently using typed parameters in step implementations - we should be.
-from typedb.api.concept.type.attribute_type import AttributeType
-from typedb.api.connection.transaction import TransactionType
-from typedb.common.label import Label
+from typedb.client import *
 
 
 @parse.with_pattern(r"true|false")

--- a/tests/behaviour/connection/database/database_steps.py
+++ b/tests/behaviour/connection/database/database_steps.py
@@ -20,12 +20,11 @@
 #
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
-from typing import List
 
 from behave import *
 from hamcrest import *
 
-from typedb.common.exception import TypeDBClientException
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_list
 from tests.behaviour.context import Context
 from tests.behaviour.util import assert_collections_equal
@@ -77,7 +76,7 @@ def delete_databases_throws_exception(context: Context, names: List[str]):
         try:
             context.client.databases().get(name).delete()
             assert False
-        except TypeDBClientException as e:
+        except TypeDBClientException:
             pass
 
 

--- a/tests/behaviour/connection/session/session_steps.py
+++ b/tests/behaviour/connection/session/session_steps.py
@@ -26,7 +26,7 @@ from typing import List
 from behave import *
 from hamcrest import *
 
-from typedb.api.connection.session import SessionType
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, parse_list
 from tests.behaviour.context import Context
 

--- a/tests/behaviour/connection/transaction/transaction_steps.py
+++ b/tests/behaviour/connection/transaction/transaction_steps.py
@@ -26,9 +26,7 @@ from typing import Callable, List
 from behave import *
 from hamcrest import *
 
-from typedb.api.connection.options import TypeDBOptions
-from typedb.api.connection.transaction import TypeDBTransaction, TransactionType
-from typedb.common.exception import TypeDBClientException
+from typedb.client import *
 from tests.behaviour.config.parameters import parse_transaction_type, parse_list, parse_bool
 from tests.behaviour.context import Context
 
@@ -262,7 +260,7 @@ def step_impl(context: Context, exception: str):
     for session in context.sessions:
         for transaction in context.sessions_to_transactions[session]:
             try:
-                next(transaction.query().define(context.text), default=None)
+                transaction.query().define(context.text).get()
                 assert False
             except TypeDBClientException as e:
                 assert_that(exception, is_in(str(e)))

--- a/tests/behaviour/connection/user/user_steps.py
+++ b/tests/behaviour/connection/user/user_steps.py
@@ -24,8 +24,7 @@ from behave import step
 from hamcrest import assert_that, has_item, not_
 
 from tests.behaviour.context import Context
-from typedb.api.connection.client import TypeDBClusterClient
-from typedb.client import TypeDB, TypeDBCredential
+from typedb.client import *
 
 
 def _get_client(context: Context):
@@ -33,21 +32,26 @@ def _get_client(context: Context):
     assert isinstance(client, TypeDBClusterClient)
     return client
 
+
 @step("users contains: {name}")
 def step_impl(context: Context, name: str):
     assert_that([u.name() for u in _get_client(context).users().all()], has_item(name))
+
 
 @step("users not contains: {name}")
 def step_impl(context: Context, name: str):
     assert_that([u.name() for u in _get_client(context).users().all()], not_(has_item(name)))
 
+
 @step("users create: {name}, {password}")
 def step_impl(context: Context, name: str, password: str):
     _get_client(context).users().create(name, password)
 
+
 @step("user password: {name}, {password}")
 def step_impl(context: Context, name: str, password: str):
     _get_client(context).users().get(name).password(password)
+
 
 @step("user connect: {name}, {password}")
 def step_impl(context: Context, name: str, password: str):
@@ -56,9 +60,8 @@ def step_impl(context: Context, name: str, password: str):
     with TypeDB.cluster_client(addresses=["127.0.0.1:" + context.config.userdata["port"]], credential=credential) as client:
         client.databases().all()
 
+
 @step("user delete: {name}")
 def step_impl(context: Context, name: str):
     user = _get_client(context).users().get(name)
     user.delete()
-
-

--- a/tests/behaviour/context.py
+++ b/tests/behaviour/context.py
@@ -19,37 +19,12 @@
 # under the License.
 #
 from concurrent.futures import Future
-from typing import List, Union, Optional, Dict
 
 import behave.runner
 from behave.model import Table
 
-from typedb.api.connection.client import TypeDBClient
-from typedb.api.answer.concept_map import ConceptMap
-from typedb.api.answer.concept_map_group import ConceptMapGroup
-from typedb.api.answer.numeric import Numeric
-from typedb.api.answer.numeric_group import NumericGroup
-from typedb.api.concept.concept import Concept
-from typedb.api.concept.thing.attribute import Attribute, BooleanAttribute, LongAttribute, DoubleAttribute, \
-    StringAttribute, DateTimeAttribute
-from typedb.api.concept.thing.entity import Entity
-from typedb.api.concept.thing.relation import Relation
-from typedb.api.concept.thing.thing import Thing
-from typedb.api.concept.type.attribute_type import AttributeType, BooleanAttributeType, LongAttributeType, \
-    DoubleAttributeType, StringAttributeType, DateTimeAttributeType
-from typedb.api.concept.type.entity_type import EntityType
-from typedb.api.concept.type.relation_type import RelationType
-from typedb.api.concept.type.role_type import RoleType
-from typedb.api.concept.type.thing_type import ThingType
-from typedb.api.concept.type.type import Type
-from typedb.api.connection.session import TypeDBSession
-from typedb.api.connection.transaction import TypeDBTransaction
+from typedb.client import *
 from tests.behaviour.config.parameters import RootLabel
-
-AttributeSubtype = Union[Attribute, BooleanAttribute, LongAttribute, DoubleAttribute, StringAttribute, DateTimeAttribute]
-ThingSubtype = Union[Thing, Entity, Relation, AttributeSubtype]
-TypeSubtype = Union[Type, ThingType, EntityType, RelationType, RoleType, AttributeType, BooleanAttributeType, LongAttributeType, DoubleAttributeType, StringAttributeType, DateTimeAttributeType]
-ConceptSubtype = Union[Concept, ThingSubtype, TypeSubtype]
 
 
 class Config:
@@ -76,7 +51,7 @@ class Context(behave.runner.Context):
         self.sessions_to_transactions: Dict[TypeDBSession, List[TypeDBTransaction]] = {}
         self.sessions_parallel: List[Future[TypeDBSession]] = []
         self.sessions_parallel_to_transactions_parallel: Dict[Future[TypeDBSession], List[TypeDBTransaction]] = {}
-        self.things: Dict[str, ThingSubtype] = {}
+        self.things: Dict[str, Thing] = {}
         self.answers: Optional[List[ConceptMap]] = None
         self.numeric_answer: Optional[Numeric] = None
         self.answer_groups: Optional[List[ConceptMapGroup]] = None
@@ -86,10 +61,10 @@ class Context(behave.runner.Context):
     def tx(self) -> TypeDBTransaction:
         return self.sessions_to_transactions[self.sessions[0]][0]
 
-    def put(self, var: str, thing: ThingSubtype) -> None:
+    def put(self, var: str, thing: Thing) -> None:
         pass
 
-    def get(self, var: str) -> ThingSubtype:
+    def get(self, var: str) -> Thing:
         pass
 
     def get_thing_type(self, root_label: RootLabel, type_label: str) -> ThingType:

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -24,7 +24,6 @@ import unittest
 from time import sleep
 from unittest import TestCase
 
-from typedb.api.connection.database import ClusterDatabaseManager
 from typedb.client import *
 
 

--- a/typedb/api/concept/concept.py
+++ b/typedb/api/concept/concept.py
@@ -21,7 +21,19 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from typedb.common.exception import TypeDBClientException, INVALID_CONCEPT_CASTING
+
 if TYPE_CHECKING:
+    from typedb.api.concept.thing.attribute import Attribute, RemoteAttribute
+    from typedb.api.concept.thing.entity import Entity, RemoteEntity
+    from typedb.api.concept.thing.relation import Relation, RemoteRelation
+    from typedb.api.concept.thing.thing import Thing, RemoteThing
+    from typedb.api.concept.type.attribute_type import AttributeType, RemoteAttributeType
+    from typedb.api.concept.type.entity_type import EntityType, RemoteEntityType
+    from typedb.api.concept.type.relation_type import RelationType, RemoteRelationType
+    from typedb.api.concept.type.role_type import RoleType, RemoteRoleType
+    from typedb.api.concept.type.thing_type import ThingType, RemoteThingType
+    from typedb.api.concept.type.type import Type, RemoteType
     from typedb.api.connection.transaction import TypeDBTransaction
 
 
@@ -57,6 +69,36 @@ class Concept(ABC):
     def is_relation(self) -> bool:
         return False
 
+    def as_type(self) -> "Type":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
+
+    def as_thing_type(self) -> "ThingType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
+
+    def as_entity_type(self) -> "EntityType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
+
+    def as_attribute_type(self) -> "AttributeType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
+
+    def as_relation_type(self) -> "RelationType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
+
+    def as_role_type(self) -> "RoleType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
+
+    def as_thing(self) -> "Thing":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
+
+    def as_entity(self) -> "Entity":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
+
+    def as_attribute(self) -> "Attribute":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
+
+    def as_relation(self) -> "Relation":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))
+
     @abstractmethod
     def as_remote(self, transaction: "TypeDBTransaction") -> "RemoteConcept":
         pass
@@ -75,3 +117,33 @@ class RemoteConcept(Concept, ABC):
     @abstractmethod
     def is_deleted(self) -> bool:
         pass
+
+    def as_type(self) -> "RemoteType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
+
+    def as_thing_type(self) -> "RemoteThingType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
+
+    def as_entity_type(self) -> "RemoteEntityType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
+
+    def as_attribute_type(self) -> "RemoteAttributeType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
+
+    def as_relation_type(self) -> "RemoteRelationType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
+
+    def as_role_type(self) -> "RemoteRoleType":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
+
+    def as_thing(self) -> "RemoteThing":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
+
+    def as_entity(self) -> "RemoteEntity":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
+
+    def as_attribute(self) -> "RemoteAttribute":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
+
+    def as_relation(self) -> "RemoteRelation":
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))

--- a/typedb/api/concept/thing/attribute.py
+++ b/typedb/api/concept/thing/attribute.py
@@ -20,7 +20,7 @@
 #
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Union
 
 from typedb.api.concept.thing.thing import Thing, RemoteThing
 
@@ -35,6 +35,10 @@ class Attribute(Thing, ABC):
 
     @abstractmethod
     def get_type(self) -> "AttributeType":
+        pass
+
+    @abstractmethod
+    def get_value(self) -> Union[bool, int, float, str, datetime]:
         pass
 
     def is_attribute(self):

--- a/typedb/client.py
+++ b/typedb/client.py
@@ -18,17 +18,48 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Union, Iterable
 
-from typedb.api.connection.client import TypeDBClient, TypeDBClusterClient
-from typedb.api.connection.credential import TypeDBCredential
 from typedb.connection.cluster.client import _ClusterClient
 from typedb.connection.core.client import _CoreClient
 
 # Repackaging these symbols allows them to be imported from "typedb.client"
-from typedb.api.connection.options import TypeDBOptions  # noqa # pylint: disable=unused-import
-from typedb.api.connection.session import TypeDBSession, SessionType  # noqa # pylint: disable=unused-import
-from typedb.api.connection.transaction import TypeDBTransaction, TransactionType  # noqa # pylint: disable=unused-import
+
+from typedb.api.answer.concept_map import *  # noqa # pylint: disable=unused-import
+from typedb.api.answer.concept_map_group import *  # noqa # pylint: disable=unused-import
+from typedb.api.answer.numeric import *  # noqa # pylint: disable=unused-import
+from typedb.api.answer.numeric_group import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.concept.thing.attribute import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.thing.entity import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.thing.relation import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.thing.thing import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.concept.type.attribute_type import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.type.entity_type import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.type.relation_type import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.type.role_type import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.type.thing_type import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.type.type import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.concept.concept import *  # noqa # pylint: disable=unused-import
+from typedb.api.concept.concept_manager import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.connection.client import *
+from typedb.api.connection.credential import *
+from typedb.api.connection.database import *  # noqa # pylint: disable=unused-import
+from typedb.api.connection.options import *  # noqa # pylint: disable=unused-import
+from typedb.api.connection.session import *  # noqa # pylint: disable=unused-import
+from typedb.api.connection.transaction import *  # noqa # pylint: disable=unused-import
+from typedb.api.connection.user import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.logic.explanation import *  # noqa # pylint: disable=unused-import
+from typedb.api.logic.logic_manager import *  # noqa # pylint: disable=unused-import
+from typedb.api.logic.rule import *  # noqa # pylint: disable=unused-import
+
+from typedb.api.query.query_manager import *  # noqa # pylint: disable=unused-import
+
+from typedb.common.exception import *  # noqa # pylint: disable=unused-import
+from typedb.common.label import *  # noqa # pylint: disable=unused-import
 
 
 class TypeDB:

--- a/typedb/concept/thing/attribute.py
+++ b/typedb/concept/thing/attribute.py
@@ -35,10 +35,15 @@ from typedb.concept.thing.thing import _Thing, _RemoteThing
 
 
 class _Attribute(Attribute, _Thing, ABC):
-    pass
+
+    def as_attribute(self) -> "Attribute":
+        return self
 
 
 class _RemoteAttribute(RemoteAttribute, _RemoteThing, ABC):
+
+    def as_attribute(self) -> "RemoteAttribute":
+        return self
 
     def get_owners(self, owner_type: ThingType = None):
         return (concept_proto_reader.thing(t) for rp in self.stream(attribute_get_owners_req(self.get_iid(), concept_proto_builder.thing_type(owner_type)))

--- a/typedb/concept/thing/entity.py
+++ b/typedb/concept/thing/entity.py
@@ -43,6 +43,9 @@ class _Entity(Entity, _Thing):
     def as_remote(self, transaction):
         return _RemoteEntity(transaction, self._iid, self.is_inferred(), self.get_type())
 
+    def as_entity(self) -> "Entity":
+        return self
+
 
 class _RemoteEntity(_RemoteThing, RemoteEntity):
 
@@ -55,3 +58,6 @@ class _RemoteEntity(_RemoteThing, RemoteEntity):
 
     def get_type(self) -> "EntityType":
         return self._type
+
+    def as_entity(self) -> "RemoteEntity":
+        return self

--- a/typedb/concept/thing/relation.py
+++ b/typedb/concept/thing/relation.py
@@ -48,6 +48,9 @@ class _Relation(Relation, _Thing):
     def get_type(self) -> "RelationType":
         return self._type
 
+    def as_relation(self) -> "Relation":
+        return self
+
 
 class _RemoteRelation(_RemoteThing, RemoteRelation):
 
@@ -60,6 +63,9 @@ class _RemoteRelation(_RemoteThing, RemoteRelation):
 
     def get_type(self) -> "RelationType":
         return self._type
+
+    def as_relation(self) -> "RemoteRelation":
+        return self
 
     def add_player(self, role_type, player):
         self.execute(relation_add_player_req(self.get_iid(), concept_proto_builder.role_type(role_type), concept_proto_builder.thing(player)))

--- a/typedb/concept/thing/thing.py
+++ b/typedb/concept/thing/thing.py
@@ -50,6 +50,9 @@ class _Thing(Thing, _Concept, ABC):
     def is_inferred(self) -> bool:
         return self._is_inferred
 
+    def as_thing(self) -> "Thing":
+        return self
+
     def __str__(self):
         return "%s[%s:%s]" % (type(self).__name__, self.get_type().get_label(), self.get_iid())
 
@@ -81,6 +84,9 @@ class _RemoteThing(_RemoteConcept, RemoteThing, ABC):
 
     def is_inferred(self) -> bool:
         return self._is_inferred
+
+    def as_thing(self) -> "RemoteThing":
+        return self
 
     def get_has(self, attribute_type=None, attribute_types: List = None, only_key=False):
         if [bool(attribute_type), bool(attribute_types), only_key].count(True) > 1:

--- a/typedb/concept/type/attribute_type.py
+++ b/typedb/concept/type/attribute_type.py
@@ -43,30 +43,33 @@ class _AttributeType(AttributeType, _ThingType):
     def as_remote(self, transaction):
         return _RemoteAttributeType(transaction, self.get_label(), self.is_root())
 
+    def as_attribute_type(self) -> "AttributeType":
+        return self
+
     def as_boolean(self):
         if self.is_root():
             return _BooleanAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, BooleanAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, BooleanAttributeType.__name__))
 
     def as_long(self):
         if self.is_root():
             return _LongAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, LongAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, LongAttributeType.__name__))
 
     def as_double(self):
         if self.is_root():
             return _DoubleAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, DoubleAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, DoubleAttributeType.__name__))
 
     def as_string(self):
         if self.is_root():
             return _StringAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, StringAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, StringAttributeType.__name__))
 
     def as_datetime(self):
         if self.is_root():
             return _DateTimeAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, DateTimeAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, DateTimeAttributeType.__name__))
 
     def __eq__(self, other):
         if other is self:
@@ -86,6 +89,9 @@ class _RemoteAttributeType(_RemoteThingType, RemoteAttributeType):
 
     def as_remote(self, transaction):
         return _RemoteAttributeType(transaction, self.get_label(), self.is_root())
+
+    def as_attribute_type(self) -> "RemoteAttributeType":
+        return self
 
     def get_subtypes(self) -> Iterator[AttributeType]:
         stream = super(_RemoteAttributeType, self).get_subtypes()
@@ -112,27 +118,27 @@ class _RemoteAttributeType(_RemoteThingType, RemoteAttributeType):
     def as_boolean(self):
         if self.is_root():
             return _BooleanAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, BooleanAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, BooleanAttributeType.__name__))
 
     def as_long(self):
         if self.is_root():
             return _LongAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, LongAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, LongAttributeType.__name__))
 
     def as_double(self):
         if self.is_root():
             return _DoubleAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, DoubleAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, DoubleAttributeType.__name__))
 
     def as_string(self):
         if self.is_root():
             return _StringAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, StringAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, StringAttributeType.__name__))
 
     def as_datetime(self):
         if self.is_root():
             return _DateTimeAttributeType(self.ROOT_LABEL, is_root=True)
-        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, DateTimeAttributeType.__name__)
+        raise TypeDBClientException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, DateTimeAttributeType.__name__))
 
     def __eq__(self, other):
         if other is self:

--- a/typedb/concept/type/entity_type.py
+++ b/typedb/concept/type/entity_type.py
@@ -37,11 +37,17 @@ class _EntityType(EntityType, _ThingType):
     def as_remote(self, transaction):
         return _RemoteEntityType(transaction, self.get_label(), self.is_root())
 
+    def as_entity_type(self) -> "EntityType":
+        return self
+
 
 class _RemoteEntityType(_RemoteThingType, RemoteEntityType):
 
     def as_remote(self, transaction):
         return _RemoteEntityType(transaction, self.get_label(), self.is_root())
+
+    def as_entity_type(self) -> "RemoteEntityType":
+        return self
 
     def create(self):
         return _Entity.of(self.execute(entity_type_create_req(self.get_label())).entity_type_create_res.entity)

--- a/typedb/concept/type/relation_type.py
+++ b/typedb/concept/type/relation_type.py
@@ -41,11 +41,17 @@ class _RelationType(RelationType, _ThingType):
     def as_remote(self, transaction):
         return _RemoteRelationType(transaction, self.get_label(), self.is_root())
 
+    def as_relation_type(self) -> "RelationType":
+        return self
+
 
 class _RemoteRelationType(_RemoteThingType, RemoteRelationType):
 
     def as_remote(self, transaction):
         return _RemoteRelationType(transaction, self.get_label(), self.is_root())
+
+    def as_relation_type(self) -> "RemoteRelationType":
+        return self
 
     def create(self):
         return _Relation.of(self.execute(relation_type_create_req(self.get_label())).relation_type_create_res.relation)

--- a/typedb/concept/type/role_type.py
+++ b/typedb/concept/type/role_type.py
@@ -37,11 +37,17 @@ class _RoleType(_Type, RoleType):
     def as_remote(self, transaction):
         return _RemoteRoleType(transaction, self.get_label(), self.is_root())
 
+    def as_role_type(self) -> "RoleType":
+        return self
+
 
 class _RemoteRoleType(_RemoteType, RemoteRoleType):
 
     def as_remote(self, transaction):
         return _RemoteRoleType(transaction, self.get_label(), self.is_root())
+
+    def as_role_type(self) -> "RemoteRoleType":
+        return self
 
     def get_relation_type(self):
         return self._transaction_ext.concepts().get_relation_type(self.get_label().scope())

--- a/typedb/concept/type/thing_type.py
+++ b/typedb/concept/type/thing_type.py
@@ -36,8 +36,20 @@ class _ThingType(ThingType, _Type):
     def as_remote(self, transaction):
         return _RemoteThingType(transaction, self.get_label(), self.is_root())
 
+    def as_thing_type(self) -> "ThingType":
+        return self
+
 
 class _RemoteThingType(_RemoteType, RemoteThingType):
+
+    def as_remote(self, transaction):
+        return _RemoteThingType(transaction, self.get_label(), self.is_root())
+
+    def as_thing_type(self) -> "RemoteThingType":
+        return self
+
+    def is_deleted(self) -> bool:
+        return not self._transaction_ext.concepts().get_thing_type(self.get_label().name())
 
     def set_supertype(self, thing_type: ThingType):
         self.execute(thing_type_set_supertype_req(self.get_label(), concept_proto_builder.thing_type(thing_type)))
@@ -71,9 +83,3 @@ class _RemoteThingType(_RemoteType, RemoteThingType):
 
     def unset_owns(self, attribute_type: AttributeType):
         self.execute(thing_type_unset_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type)))
-
-    def as_remote(self, transaction):
-        return _RemoteThingType(transaction, self.get_label(), self.is_root())
-
-    def is_deleted(self) -> bool:
-        return not self._transaction_ext.concepts().get_thing_type(self.get_label().name())

--- a/typedb/concept/type/type.py
+++ b/typedb/concept/type/type.py
@@ -50,6 +50,9 @@ class _Type(Type, _Concept, ABC):
     def is_root(self):
         return self._is_root
 
+    def as_type(self) -> "Type":
+        return self
+
     def __str__(self):
         return type(self).__name__ + "[label: %s]" % self.get_label()
 
@@ -81,6 +84,9 @@ class _RemoteType(RemoteType, _RemoteConcept, ABC):
 
     def is_root(self):
         return self._is_root
+
+    def as_type(self) -> "RemoteType":
+        return self
 
     def set_label(self, new_label: str):
         self.execute(type_set_label_req(self.get_label(), new_label))


### PR DESCRIPTION
## What is the goal of this PR?

We added methods to cast concept types to each other: for example `concept.as_attribute()` will now cast a `Concept` to an `Attribute`, throwing an exception if it is not actually an `Attribute`. This aids type checking systems.

Also, all the `Concept` types are now importable from `typedb.client` directly.

## What are the changes implemented in this PR?

Add concept cast methods, and add all Concept types to typedb.client
