### PR TITLE
Enable faster authentication with "user token" mechanism

### DIFF
--- a/typedb/common/exception.py
+++ b/typedb/common/exception.py
@@ -38,6 +38,7 @@ class TypeDBClientException(Exception):
 
     @staticmethod
     def of_rpc(rpc_error: Union[RpcError, Call]) -> "TypeDBClientException":
+        print(rpc_error)
         if rpc_error.code() in [StatusCode.UNAVAILABLE, StatusCode.UNKNOWN] or "Received RST_STREAM" in str(rpc_error):
             return TypeDBClientException(msg=UNABLE_TO_CONNECT, cause=rpc_error)
         elif rpc_error.code() is StatusCode.INTERNAL and "[RPL01]" in str(rpc_error):

--- a/typedb/common/exception.py
+++ b/typedb/common/exception.py
@@ -88,9 +88,10 @@ CLUSTER_NO_PRIMARY_REPLICA_YET = ClientErrorMessage(10, "No replica has been mar
 CLUSTER_UNABLE_TO_CONNECT = ClientErrorMessage(11, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.")
 CLUSTER_REPLICA_NOT_PRIMARY = ClientErrorMessage(12, "The replica is not the primary replica.")
 CLUSTER_ALL_NODES_FAILED = ClientErrorMessage(13, "Attempted connecting to all cluster members, but the following errors occurred: \n%s")
-CLUSTER_INVALID_ROOT_CA_PATH = ClientErrorMessage(14, "The provided Root CA path '%s' does not exist.")
-CLUSTER_USER_DOES_NOT_EXIST = ClientErrorMessage(15, "The user '%s' does not exist.")
-CLUSTER_CLIENT_CALLED_WITH_STRING = ClientErrorMessage(16, "The first argument of TypeDBClient.cluster() must be a List of server addresses to connect to. It was called with a string, not a List, which is not allowed.")
+CLUSTER_USER_DOES_NOT_EXIST = ClientErrorMessage(14, "The user '%s' does not exist.")
+CLUSTER_TOKEN_CREDENTIAL_INVALID = ClientErrorMessage(15, "Invalid token credential.")
+CLUSTER_INVALID_ROOT_CA_PATH = ClientErrorMessage(16, "The provided Root CA path '%s' does not exist.")
+CLUSTER_CLIENT_CALLED_WITH_STRING = ClientErrorMessage(17, "The first argument of TypeDBClient.cluster() must be a List of server addresses to connect to. It was called with a string, not a List, which is not allowed.")
 
 
 class ConceptErrorMessage(ErrorMessage):

--- a/typedb/common/exception.py
+++ b/typedb/common/exception.py
@@ -38,7 +38,6 @@ class TypeDBClientException(Exception):
 
     @staticmethod
     def of_rpc(rpc_error: Union[RpcError, Call]) -> "TypeDBClientException":
-        print(rpc_error)
         if rpc_error.code() in [StatusCode.UNAVAILABLE, StatusCode.UNKNOWN] or "Received RST_STREAM" in str(rpc_error):
             return TypeDBClientException(msg=UNABLE_TO_CONNECT, cause=rpc_error)
         elif rpc_error.code() is StatusCode.INTERNAL and "[RPL01]" in str(rpc_error):

--- a/typedb/common/rpc/stub.py
+++ b/typedb/common/rpc/stub.py
@@ -20,14 +20,16 @@
 #
 
 from abc import ABC
-from typing import Callable, Iterator, TypeVar
+from typing import Iterator
+from typing import TypeVar, Callable
 
 import typedb_protocol.common.session_pb2 as session_proto
 import typedb_protocol.common.transaction_pb2 as transaction_proto
 import typedb_protocol.core.core_database_pb2 as core_database_proto
 import typedb_protocol.core.core_service_pb2_grpc as core_service_proto
-from grpc import Channel
+from grpc import Channel, RpcError
 
+from typedb.common.exception import TypeDBClientException
 
 T = TypeVar('T')
 
@@ -68,4 +70,8 @@ class TypeDBStub(ABC):
         pass
 
     def resilient_call(self, function: Callable[[], T]) -> T:
-        pass
+        try:
+            # TODO actually implement forced gRPC to reconnected rapidly, which provides resilience
+            return function()
+        except RpcError as e:
+            raise TypeDBClientException.of_rpc(e)

--- a/typedb/common/rpc/stub.py
+++ b/typedb/common/rpc/stub.py
@@ -20,60 +20,49 @@
 #
 
 from abc import ABC
-from typing import TypeVar, Callable, Iterator
-
+from typing import Callable, Iterator
 
 import typedb_protocol.common.session_pb2 as session_proto
 import typedb_protocol.common.transaction_pb2 as transaction_proto
 import typedb_protocol.core.core_database_pb2 as core_database_proto
 import typedb_protocol.core.core_service_pb2_grpc as core_service_proto
-
-from grpc import Channel, RpcError
-
-from typedb.common.exception import TypeDBClientException
-
-T = TypeVar('T')
-
-
-def resilient_call(function: Callable[[], T]) -> T:
-    try:
-        # TODO actually implement forced gRPC to reconnected rapidly, which provides resilience
-        return function()
-    except RpcError as e:
-        raise TypeDBClientException.of_rpc(e)
+from grpc import Channel
 
 
 class TypeDBStub(ABC):
 
     def databases_contains(self, req: core_database_proto.CoreDatabaseManager.Contains.Req) -> core_database_proto.CoreDatabaseManager.Contains.Res:
-        return resilient_call(lambda: self.stub().databases_contains(req))
+        return self.resilient_call(lambda: self.stub().databases_contains(req))
 
     def databases_create(self, req: core_database_proto.CoreDatabaseManager.Create.Req) -> core_database_proto.CoreDatabaseManager.Create.Res:
-        return resilient_call(lambda: self.stub().databases_create(req))
+        return self.resilient_call(lambda: self.stub().databases_create(req))
 
     def databases_all(self, req: core_database_proto.CoreDatabaseManager.All.Req) -> core_database_proto.CoreDatabaseManager.All.Res:
-        return resilient_call(lambda: self.stub().databases_all(req))
+        return self.resilient_call(lambda: self.stub().databases_all(req))
 
     def database_schema(self, req: core_database_proto.CoreDatabase.Schema.Req) -> core_database_proto.CoreDatabase.Schema.Res:
-        return resilient_call(lambda: self.stub().database_schema(req))
+        return self.resilient_call(lambda: self.stub().database_schema(req))
 
     def database_delete(self, req: core_database_proto.CoreDatabase.Delete.Req) -> core_database_proto.CoreDatabase.Delete.Res:
-        return resilient_call(lambda: self.stub().database_delete(req))
+        return self.resilient_call(lambda: self.stub().database_delete(req))
 
     def session_open(self, req: session_proto.Session.Open.Req) -> session_proto.Session.Open.Res:
-        return resilient_call(lambda: self.stub().session_open(req))
+        return self.resilient_call(lambda: self.stub().session_open(req))
 
     def session_close(self, req: session_proto.Session.Close.Req) -> session_proto.Session.Close.Res:
-        return resilient_call(lambda: self.stub().session_close(req))
+        return self.resilient_call(lambda: self.stub().session_close(req))
 
     def session_pulse(self, req: session_proto.Session.Pulse.Req) -> session_proto.Session.Pulse.Res:
-        return resilient_call(lambda: self.stub().session_pulse(req))
+        return self.resilient_call(lambda: self.stub().session_pulse(req))
 
     def transaction(self, request_iterator: Iterator[transaction_proto.Transaction.Client]) -> Iterator[transaction_proto.Transaction.Server]:
-        return resilient_call(lambda: self.stub().transaction(request_iterator))
+        return self.resilient_call(lambda: self.stub().transaction(request_iterator))
 
     def channel(self) -> Channel:
         pass
 
     def stub(self) -> core_service_proto.TypeDBStub:
+        pass
+
+    def resilient_call(self, function: Callable[[], T]) -> T:
         pass

--- a/typedb/common/rpc/stub.py
+++ b/typedb/common/rpc/stub.py
@@ -42,36 +42,38 @@ def resilient_call(function: Callable[[], T]) -> T:
     except RpcError as e:
         raise TypeDBClientException.of_rpc(e)
 
+
 class TypeDBStub(ABC):
 
-    def __init__(self, channel: Channel, stub: core_service_proto.TypeDBStub):
-        self._channel = channel
-        self._stub = stub
-
     def databases_contains(self, req: core_database_proto.CoreDatabaseManager.Contains.Req) -> core_database_proto.CoreDatabaseManager.Contains.Res:
-        return resilient_call(lambda: self._stub.databases_contains(req))
+        return resilient_call(lambda: self.stub().databases_contains(req))
 
     def databases_create(self, req: core_database_proto.CoreDatabaseManager.Create.Req) -> core_database_proto.CoreDatabaseManager.Create.Res:
-        return resilient_call(lambda: self._stub.databases_create(req))
+        return resilient_call(lambda: self.stub().databases_create(req))
 
     def databases_all(self, req: core_database_proto.CoreDatabaseManager.All.Req) -> core_database_proto.CoreDatabaseManager.All.Res:
-        return resilient_call(lambda: self._stub.databases_all(req))
+        return resilient_call(lambda: self.stub().databases_all(req))
 
     def database_schema(self, req: core_database_proto.CoreDatabase.Schema.Req) -> core_database_proto.CoreDatabase.Schema.Res:
-        return resilient_call(lambda: self._stub.database_schema(req))
+        return resilient_call(lambda: self.stub().database_schema(req))
 
     def database_delete(self, req: core_database_proto.CoreDatabase.Delete.Req) -> core_database_proto.CoreDatabase.Delete.Res:
-        return resilient_call(lambda: self._stub.database_delete(req))
+        return resilient_call(lambda: self.stub().database_delete(req))
 
     def session_open(self, req: session_proto.Session.Open.Req) -> session_proto.Session.Open.Res:
-        return resilient_call(lambda: self._stub.session_open(req))
+        return resilient_call(lambda: self.stub().session_open(req))
 
     def session_close(self, req: session_proto.Session.Close.Req) -> session_proto.Session.Close.Res:
-        return resilient_call(lambda: self._stub.session_close(req))
+        return resilient_call(lambda: self.stub().session_close(req))
 
     def session_pulse(self, req: session_proto.Session.Pulse.Req) -> session_proto.Session.Pulse.Res:
-        return resilient_call(lambda: self._stub.session_pulse(req))
+        return resilient_call(lambda: self.stub().session_pulse(req))
 
     def transaction(self, request_iterator: Iterator[transaction_proto.Transaction.Client]) -> Iterator[transaction_proto.Transaction.Server]:
-        return resilient_call(lambda: self._stub.transaction(request_iterator))
+        return resilient_call(lambda: self.stub().transaction(request_iterator))
 
+    def channel(self) -> Channel:
+        pass
+
+    def stub(self) -> core_service_proto.TypeDBStub:
+        pass

--- a/typedb/common/rpc/stub.py
+++ b/typedb/common/rpc/stub.py
@@ -20,13 +20,16 @@
 #
 
 from abc import ABC
-from typing import Callable, Iterator
+from typing import Callable, Iterator, TypeVar
 
 import typedb_protocol.common.session_pb2 as session_proto
 import typedb_protocol.common.transaction_pb2 as transaction_proto
 import typedb_protocol.core.core_database_pb2 as core_database_proto
 import typedb_protocol.core.core_service_pb2_grpc as core_service_proto
 from grpc import Channel
+
+
+T = TypeVar('T')
 
 
 class TypeDBStub(ABC):

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -46,7 +46,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
 
     def new_channel_and_stub(self) -> (grpc.Channel, _ClusterServerStub):
         channel = self._new_channel()
-        return channel, _ClusterServerStub(channel)
+        return channel, _ClusterServerStub(channel, self._credential)
 
     def _new_channel(self) -> grpc.Channel:
         if self._credential.tls_root_ca_path() is not None:

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -50,7 +50,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
 
     def new_channel_and_stub(self) -> (grpc.Channel, _ClusterServerStub):
         channel = self._new_channel()
-        return channel, _ClusterServerStub.create(channel)
+        return channel, _ClusterServerStub(channel)
 
     def _new_channel(self) -> grpc.Channel:
         if self._credential.tls_root_ca_path() is not None:

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -73,6 +73,6 @@ class _CredentialAuth(grpc.AuthMetadataPlugin):
     def __call__(self, context, callback):
         token = self._token()
         if token is None:
-            callback((('username', self._credential.username()), ('password', self._credential.password())), None)
+            callback((('username', self._credential().username()), ('password', self._credential().password())), None)
         else:
             callback((('token', token)), None)

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -34,6 +34,10 @@ class _ClusterServerClient(_TypeDBClientImpl):
         self._credential = credential
         self._channel, self._stub = self.new_channel_and_stub()
         self._databases = _TypeDBDatabaseManagerImpl(self.stub())
+        try:
+            self._token = self._stub.user_token_renew()
+        except ArithmeticError as e:
+            pass
 
     def databases(self) -> _TypeDBDatabaseManagerImpl:
         return self._databases

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -74,6 +74,6 @@ class _CredentialAuth(grpc.AuthMetadataPlugin):
     def __call__(self, context, callback):
         token = self._token_fn()
         if token is None:
-            callback((('username', self._credential.username()), ('password', self._credential().password())), None)
+            callback((('username', self._credential.username()), ('password', self._credential.password())), None)
         else:
             callback((('token', token)), None)

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -18,6 +18,7 @@
 #   specific language governing permissions and limitations
 #   under the License.
 #
+from typing import Callable
 
 import grpc
 
@@ -56,7 +57,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
             channel_credentials = grpc.ssl_channel_credentials()
         combined_credentials = grpc.composite_channel_credentials(
             channel_credentials,
-            grpc.metadata_call_credentials(_CredentialAuth(lambda: self._credential, lambda: self._stub.token()))
+            grpc.metadata_call_credentials(_CredentialAuth(credential=self._credential, token_fn=lambda: self._stub.token()))
         )
         return grpc.secure_channel(self._address, combined_credentials)
 
@@ -66,13 +67,13 @@ class _ClusterServerClient(_TypeDBClientImpl):
 
 
 class _CredentialAuth(grpc.AuthMetadataPlugin):
-    def __init__(self, credential, token):
+    def __init__(self, credential, token_fn: Callable[[], str]):
         self._credential = credential
-        self._token = token
+        self._token_fn = token_fn
 
     def __call__(self, context, callback):
-        token = self._token()
+        token = self._token_fn()
         if token is None:
-            callback((('username', self._credential().username()), ('password', self._credential().password())), None)
+            callback((('username', self._credential.username()), ('password', self._credential().password())), None)
         else:
             callback((('token', token)), None)

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -56,7 +56,7 @@ class _ClusterServerClient(_TypeDBClientImpl):
             channel_credentials = grpc.ssl_channel_credentials()
         combined_credentials = grpc.composite_channel_credentials(
             channel_credentials,
-            grpc.metadata_call_credentials(_CredentialAuth(self._credential.username(), self._credential.password()))
+            grpc.metadata_call_credentials(_CredentialAuth(lambda: self._credential, lambda: self._stub.token()))
         )
         return grpc.secure_channel(self._address, combined_credentials)
 
@@ -66,9 +66,13 @@ class _ClusterServerClient(_TypeDBClientImpl):
 
 
 class _CredentialAuth(grpc.AuthMetadataPlugin):
-    def __init__(self, username, password):
-        self._username = username
-        self._password = password
+    def __init__(self, credential, token):
+        self._credential = credential
+        self._token = token
 
     def __call__(self, context, callback):
-        callback((('username', self._username), ('password', self._password)), None)
+        token = self._token()
+        if token is None:
+            callback((('username', self._credential.username()), ('password', self._credential.password())), None)
+        else:
+            callback((('token', token)), None)

--- a/typedb/connection/cluster/server_client.py
+++ b/typedb/connection/cluster/server_client.py
@@ -34,10 +34,6 @@ class _ClusterServerClient(_TypeDBClientImpl):
         self._credential = credential
         self._channel, self._stub = self.new_channel_and_stub()
         self._databases = _TypeDBDatabaseManagerImpl(self.stub())
-        try:
-            self._token = self._stub.user_token_renew()
-        except ArithmeticError as e:
-            pass
 
     def databases(self) -> _TypeDBDatabaseManagerImpl:
         return self._databases

--- a/typedb/connection/cluster/stub.py
+++ b/typedb/connection/cluster/stub.py
@@ -30,17 +30,11 @@ from typedb.common.rpc.stub import TypeDBStub, resilient_call
 
 class _ClusterServerStub(TypeDBStub):
 
-    def __init__(self, channel: Channel, stub: core_service_proto.TypeDBStub, clusterStub: cluster_service_proto.TypeDBClusterStub):
-        super(_ClusterServerStub, self).__init__(channel, stub)
-        self._clusterStub = clusterStub
-
-    @staticmethod
-    def create(channel: Channel):
-        return _ClusterServerStub(
-            channel,
-            core_service_proto.TypeDBStub(channel),
-            cluster_service_proto.TypeDBClusterStub(channel)
-        )
+    def __init__(self, channel: Channel):
+        super(_ClusterServerStub, self).__init__()
+        self._channel = channel
+        self._stub = core_service_proto.TypeDBStub(channel)
+        self._clusterStub = cluster_service_proto.TypeDBClusterStub(channel)
 
     def servers_all(self, req: cluster_server_proto.ServerManager.All.Req) -> cluster_server_proto.ServerManager.All.Res:
         return resilient_call(lambda: self._clusterStub.servers_all(req))
@@ -66,3 +60,8 @@ class _ClusterServerStub(TypeDBStub):
     def user_delete(self, req: cluster_user_proto.ClusterUser.Delete.Req) -> cluster_user_proto.ClusterUser.Delete.Res:
         return resilient_call(lambda: self._clusterStub.user_delete(req))
 
+    def channel(self) -> Channel:
+        return self._channel
+
+    def stub(self) -> TypeDBStub:
+        return self._stub

--- a/typedb/connection/cluster/stub.py
+++ b/typedb/connection/cluster/stub.py
@@ -42,6 +42,7 @@ class _ClusterServerStub(TypeDBStub):
         self._channel = channel
         self._stub = core_service_proto.TypeDBStub(channel)
         self._cluster_stub = cluster_service_proto.TypeDBClusterStub(channel)
+        self._token = None
         try:
             self._token = self._cluster_stub.user_token_renew(self._credential.username())
         except RpcError as e:

--- a/typedb/connection/cluster/stub.py
+++ b/typedb/connection/cluster/stub.py
@@ -86,14 +86,14 @@ class _ClusterServerStub(TypeDBStub):
     def resilient_authenticated_call(self, function: Callable[[], T]) -> T:
         try:
             return self.resilient_call(function)
-        except TypeDBClientException as e2:
-            if e2.error_message is not None and e2.error_message is CLUSTER_TOKEN_CREDENTIAL_INVALID:
+        except TypeDBClientException as e:
+            if e.error_message is not None and e.error_message is CLUSTER_TOKEN_CREDENTIAL_INVALID:
                 self._token = None
                 res = self._cluster_stub.user_token_renew(self._credential.username())
                 self._token = res.token
                 try:
                     return self.resilient_call(function)
-                except RpcError as e3:
-                    raise TypeDBClientException.of_rpc(e3)
+                except RpcError as e2:
+                    raise TypeDBClientException.of_rpc(e2)
             else:
-                raise e2
+                raise e

--- a/typedb/connection/cluster/stub.py
+++ b/typedb/connection/cluster/stub.py
@@ -34,31 +34,31 @@ class _ClusterServerStub(TypeDBStub):
         super(_ClusterServerStub, self).__init__()
         self._channel = channel
         self._stub = core_service_proto.TypeDBStub(channel)
-        self._clusterStub = cluster_service_proto.TypeDBClusterStub(channel)
+        self._cluster_stub = cluster_service_proto.TypeDBClusterStub(channel)
 
     def servers_all(self, req: cluster_server_proto.ServerManager.All.Req) -> cluster_server_proto.ServerManager.All.Res:
-        return resilient_call(lambda: self._clusterStub.servers_all(req))
+        return resilient_call(lambda: self._cluster_stub.servers_all(req))
 
     def databases_get(self, req: cluster_database_proto.ClusterDatabaseManager.Get.Req) -> cluster_database_proto.ClusterDatabaseManager.Get.Res:
-        return resilient_call(lambda: self._clusterStub.databases_get(req))
+        return resilient_call(lambda: self._cluster_stub.databases_get(req))
 
     def databases_all(self, req: cluster_database_proto.ClusterDatabaseManager.All.Req) -> cluster_database_proto.ClusterDatabaseManager.All.Res:
-        return resilient_call(lambda: self._clusterStub.databases_all(req))
+        return resilient_call(lambda: self._cluster_stub.databases_all(req))
 
     def users_all(self, req: cluster_user_proto.ClusterUserManager.All.Req) -> cluster_user_proto.ClusterUserManager.All.Res:
-        return resilient_call(lambda: self._clusterStub.users_all(req))
+        return resilient_call(lambda: self._cluster_stub.users_all(req))
 
     def users_contains(self, req: cluster_user_proto.ClusterUserManager.Contains.Req) -> cluster_user_proto.ClusterUserManager.Contains.Res:
-        return resilient_call(lambda: self._clusterStub.users_contains(req))
+        return resilient_call(lambda: self._cluster_stub.users_contains(req))
 
     def users_create(self, req: cluster_user_proto.ClusterUserManager.Create.Req) -> cluster_user_proto.ClusterUserManager.Create.Res:
-        return resilient_call(lambda: self._clusterStub.users_create(req))
+        return resilient_call(lambda: self._cluster_stub.users_create(req))
 
     def user_password(self, req: cluster_user_proto.ClusterUser.Delete.Req) -> cluster_user_proto.ClusterUser.Delete.Res:
-        return resilient_call(lambda: self._clusterStub.user_password(req))
+        return resilient_call(lambda: self._cluster_stub.user_password(req))
 
     def user_delete(self, req: cluster_user_proto.ClusterUser.Delete.Req) -> cluster_user_proto.ClusterUser.Delete.Res:
-        return resilient_call(lambda: self._clusterStub.user_delete(req))
+        return resilient_call(lambda: self._cluster_stub.user_delete(req))
 
     def channel(self) -> Channel:
         return self._channel

--- a/typedb/connection/core/client.py
+++ b/typedb/connection/core/client.py
@@ -45,7 +45,7 @@ class _CoreClient(_TypeDBClientImpl):
 
     def new_channel_and_stub(self) -> (Channel, _CoreStub):
         channel = insecure_channel(self._address)
-        return channel, _CoreStub.create(channel)
+        return channel, _CoreStub(channel)
 
     def close(self) -> None:
         super().close()

--- a/typedb/connection/core/stub.py
+++ b/typedb/connection/core/stub.py
@@ -26,9 +26,13 @@ from typedb.common.rpc.stub import TypeDBStub
 
 class _CoreStub(TypeDBStub):
 
-    def __init__(self, channel: Channel, stub: core_service_proto.TypeDBStub):
-        super(_CoreStub, self).__init__(channel, stub)
+    def __init__(self, channel: Channel):
+        super(_CoreStub, self).__init__()
+        self._channel = channel
+        self._stub = core_service_proto.TypeDBStub(channel)
 
-    @staticmethod
-    def create(channel: Channel):
-        return _CoreStub(channel, core_service_proto.TypeDBStub(channel))
+    def channel(self) -> Channel:
+        return self._channel
+
+    def stub(self) -> TypeDBStub:
+        return self._stub

--- a/typedb/connection/core/stub.py
+++ b/typedb/connection/core/stub.py
@@ -18,15 +18,15 @@
 #   specific language governing permissions and limitations
 #   under the License.
 #
-from typing import TypeVar, Callable
+from typing import TypeVar
 
 import typedb_protocol.core.core_service_pb2_grpc as core_service_proto
-from grpc import Channel, RpcError
+from grpc import Channel
 
-from typedb.common.exception import TypeDBClientException
 from typedb.common.rpc.stub import TypeDBStub
 
 T = TypeVar('T')
+
 
 class _CoreStub(TypeDBStub):
 
@@ -40,11 +40,3 @@ class _CoreStub(TypeDBStub):
 
     def stub(self) -> TypeDBStub:
         return self._stub
-
-    def resilient_call(self, function: Callable[[], T]) -> T:
-        try:
-            # TODO actually implement forced gRPC to reconnected rapidly, which provides resilience
-            return function()
-        except RpcError as e:
-            raise TypeDBClientException.of_rpc(e)
-


### PR DESCRIPTION
## What is the goal of this PR?

Authenticating a user by verifying their password introduces a significant overhead, which comes from the fact that the password is hashed with cryptographic hash function. In effect, opening a new session or transaction becomes much slower.

We've now improved the speed of user-authentication by introducing a mechanism for verifying user credential with cheap "user token" rather than password.

## What are the changes implemented in this PR?

- `ClusterServerStub` performs an attempt to retrieve user token when instantiated. Should the attempt fail, it will be retried the next time.
- The `resilient_call` method of `ClusterServerStub` may renew the token and then reattempt the call if the token is no longer valid