### PR TITLE
Move session pulse transmitter to the Client

### DIFF
--- a/typedb/connection/client.py
+++ b/typedb/connection/client.py
@@ -18,9 +18,15 @@
 #   specific language governing permissions and limitations
 #   under the License.
 #
+import sched
+import time
+from threading import Thread, Lock
 from typing import Dict
+from uuid import uuid4
 
 from grpc import Channel
+
+import typedb_protocol.common.session_pb2 as session_proto
 
 from typedb.api.connection.client import TypeDBClient
 from typedb.api.connection.options import TypeDBOptions
@@ -30,25 +36,34 @@ from typedb.connection.database_manager import _TypeDBDatabaseManagerImpl
 from typedb.connection.session import _TypeDBSessionImpl
 from typedb.stream.request_transmitter import RequestTransmitter
 
+from typedb.common.exception import TypeDBClientException
+
 
 class _TypeDBClientImpl(TypeDBClient):
+    _PULSE_INTERVAL_SECONDS = 5
 
     # TODO: Detect number of available CPUs
     def __init__(self, address: str, parallelisation: int = 2):
         self._address = address
         self._transmitter = RequestTransmitter(parallelisation)
         self._sessions: Dict[bytes, _TypeDBSessionImpl] = {}
+        self._sessions_lock = Lock()
         self._is_open = True
+        self._pulse_scheduler = sched.scheduler(time.time, time.sleep)
+        self._pulse = self._pulse_scheduler.enter(delay=self._PULSE_INTERVAL_SECONDS, priority=1, action=self._transmit_pulses, argument=())
+        Thread(target=self._pulse_scheduler.run, name="session_pulse_{}".format(uuid4()), daemon=True).start()
 
     def session(self, database: str, session_type: SessionType, options=None) -> _TypeDBSessionImpl:
         if not options:
             options = TypeDBOptions.core()
         session = _TypeDBSessionImpl(self, database, session_type, options)
-        self._sessions[session.session_id()] = session
+        with self._sessions_lock:
+            self._sessions[session.session_id()] = session
         return session
 
     def remove_session(self, session: _TypeDBSessionImpl) -> None:
-        del self._sessions[session.session_id()]
+        with self._sessions_lock:
+            del self._sessions[session.session_id()]
 
     def databases(self) -> _TypeDBDatabaseManagerImpl:
         pass
@@ -84,5 +99,24 @@ class _TypeDBClientImpl(TypeDBClient):
 
     def close(self) -> None:
         self._is_open = False
-        for session_id in self._sessions:
-            self._sessions[session_id].close()
+        with self._sessions_lock:
+            sessions = self._sessions.copy()
+        for (session_id, session) in sessions.items():
+            session.close()
+
+    def _transmit_pulses(self) -> None:
+        if not self.is_open():
+            return
+        with self._sessions_lock:
+            sessions = self._sessions.copy()
+        for (session_id, session) in sessions.items():
+            pulse_req = session_proto.Session.Pulse.Req()
+            pulse_req.session_id = session_id
+            try:
+                alive = self.stub().session_pulse(pulse_req).alive
+            except TypeDBClientException:
+                alive = False
+            if not alive:
+                session.close()
+        self._pulse = self._pulse_scheduler.enter(delay=self._PULSE_INTERVAL_SECONDS, priority=1, action=self._transmit_pulses, argument=())
+        Thread(target=self._pulse_scheduler.run, name="session_pulse_{}".format(uuid4()), daemon=True).start()


### PR DESCRIPTION
## What is the goal of this PR?

Instead of launching a background thread in each session to send pulses, we now use a single thread in the Client to send pulses for all of its sessions. This allows the client to handle a much larger number of sessions than it previously could.

## What are the changes implemented in this PR?

**Changeset**
- Move session pulse transmitter to the Client

**Fixes**
- fixes https://github.com/vaticle/typedb-client-python/issues/222
- may reduce the chance of seeing https://github.com/vaticle/typedb-client-python/issues/243