### PR TITLE
Extend concept type API

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "6eb5e84deffc55d06d7e205ba6414a647b247ada"
+        tag = "2.9.0",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0f84e6577b6ef60dac838b604e6d66222c512957",
+        tag = "2.9.0",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "aa8531f154d7c74c8922c71a252022c650c1be0c"
+        commit = "6eb5e84deffc55d06d7e205ba6414a647b247ada"
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "184bc8a64aa69e383bf496c70b11f02201d33616" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "6e462bcbef73c75405264777069a22bca696a644" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,19 +25,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "465e60776ca3055ce85d90e94624d37db3f7e790",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "d11cee9745e4559450ef4ccb140d4e9781587932" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.9.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "7aa405c01eb46b8a28867bc49c4f8c0427c32d52", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "184bc8a64aa69e383bf496c70b11f02201d33616" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "465e60776ca3055ce85d90e94624d37db3f7e790",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-typedb-protocol==2.6.0
+typedb-protocol==2.9.0
 grpcio==1.43.0
 protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,7 +30,7 @@
 
 ## Dependencies
 
-typedb-protocol==2.6.0
+typedb-protocol==2.9.0
 grpcio==1.43.0
 protobuf==3.15.5
 

--- a/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
+++ b/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
@@ -23,7 +23,7 @@ from behave import *
 from hamcrest import *
 
 from typedb.client import *
-from tests.behaviour.config.parameters import parse_value_type, parse_list, parse_label
+from tests.behaviour.config.parameters import parse_value_type, parse_list, parse_scoped_label
 from tests.behaviour.context import Context
 
 
@@ -65,7 +65,7 @@ def attribute_type_as_value_type(context: Context, type_label: str, value_type: 
 
 @step("attribute({type_label}) as({value_type}) get subtypes contain")
 def step_impl(context: Context, type_label: str, value_type: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = attribute_type_as_value_type(context, type_label, parse_value_type(value_type))
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_subtypes()))
     for sub_label in sub_labels:
@@ -74,7 +74,7 @@ def step_impl(context: Context, type_label: str, value_type: str):
 
 @step("attribute({type_label}) as({value_type}) get subtypes do not contain")
 def step_impl(context: Context, type_label: str, value_type: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = attribute_type_as_value_type(context, type_label, parse_value_type(value_type))
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_subtypes()))
     for sub_label in sub_labels:
@@ -115,7 +115,7 @@ def step_impl(context: Context, type_label: str, value_type):
 
 @step("attribute({type_label}) get key owners contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=True)))
     for owner_label in owner_labels:
@@ -124,7 +124,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=True)))
     for owner_label in owner_labels:
@@ -133,7 +133,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners explicit contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(
         map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
@@ -143,7 +143,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners explicit do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(
         map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
@@ -153,7 +153,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=False)))
     for owner_label in owner_labels:
@@ -162,7 +162,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=False)))
     for owner_label in owner_labels:
@@ -171,7 +171,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners explicit contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
     for owner_label in owner_labels:
@@ -180,7 +180,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners explicit do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
     for owner_label in owner_labels:

--- a/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
+++ b/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
@@ -34,12 +34,14 @@ def step_impl(context: Context, type_label: str, value_type: str):
 
 @step("attribute({type_label}) get value type: {value_type}")
 def step_impl(context: Context, type_label: str, value_type: str):
-    assert_that(context.tx().concepts().get_attribute_type(type_label).get_value_type(), is_(parse_value_type(value_type)))
+    assert_that(context.tx().concepts().get_attribute_type(type_label).get_value_type(),
+                is_(parse_value_type(value_type)))
 
 
 @step("attribute({type_label}) get supertype value type: {value_type}")
 def step_impl(context: Context, type_label: str, value_type: str):
-    supertype = context.tx().concepts().get_attribute_type(type_label).as_remote(context.tx()).get_supertype().as_attribute_type()
+    supertype = context.tx().concepts().get_attribute_type(type_label).as_remote(
+        context.tx()).get_supertype().as_attribute_type()
     assert_that(supertype.get_value_type(), is_(parse_value_type(value_type)))
 
 
@@ -129,6 +131,26 @@ def step_impl(context: Context, type_label: str):
         assert_that(actuals, not_(has_item(owner_label)))
 
 
+@step("attribute({type_label}) get key owners explicit contain")
+def step_impl(context: Context, type_label: str):
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_type = context.tx().concepts().get_attribute_type(type_label)
+    actuals = list(
+        map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
+    for owner_label in owner_labels:
+        assert_that(actuals, has_item(owner_label))
+
+
+@step("attribute({type_label}) get key owners explicit do not contain")
+def step_impl(context: Context, type_label: str):
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_type = context.tx().concepts().get_attribute_type(type_label)
+    actuals = list(
+        map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
+    for owner_label in owner_labels:
+        assert_that(actuals, not_(has_item(owner_label)))
+
+
 @step("attribute({type_label}) get attribute owners contain")
 def step_impl(context: Context, type_label: str):
     owner_labels = [parse_label(s) for s in parse_list(context.table)]
@@ -143,5 +165,23 @@ def step_impl(context: Context, type_label: str):
     owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=False)))
+    for owner_label in owner_labels:
+        assert_that(actuals, not_(has_item(owner_label)))
+
+
+@step("attribute({type_label}) get attribute owners explicit contain")
+def step_impl(context: Context, type_label: str):
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_type = context.tx().concepts().get_attribute_type(type_label)
+    actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
+    for owner_label in owner_labels:
+        assert_that(actuals, has_item(owner_label))
+
+
+@step("attribute({type_label}) get attribute owners explicitdo not contain")
+def step_impl(context: Context, type_label: str):
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_type = context.tx().concepts().get_attribute_type(type_label)
+    actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
     for owner_label in owner_labels:
         assert_that(actuals, not_(has_item(owner_label)))

--- a/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
+++ b/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
@@ -178,7 +178,7 @@ def step_impl(context: Context, type_label: str):
         assert_that(actuals, has_item(owner_label))
 
 
-@step("attribute({type_label}) get attribute owners explicitdo not contain")
+@step("attribute({type_label}) get attribute owners explicit do not contain")
 def step_impl(context: Context, type_label: str):
     owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)

--- a/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
+++ b/tests/behaviour/concept/type/attributetype/attribute_type_steps.py
@@ -23,7 +23,7 @@ from behave import *
 from hamcrest import *
 
 from typedb.client import *
-from tests.behaviour.config.parameters import parse_value_type, parse_list, parse_scoped_label
+from tests.behaviour.config.parameters import parse_value_type, parse_list, parse_label
 from tests.behaviour.context import Context
 
 
@@ -65,7 +65,7 @@ def attribute_type_as_value_type(context: Context, type_label: str, value_type: 
 
 @step("attribute({type_label}) as({value_type}) get subtypes contain")
 def step_impl(context: Context, type_label: str, value_type: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = attribute_type_as_value_type(context, type_label, parse_value_type(value_type))
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_subtypes()))
     for sub_label in sub_labels:
@@ -74,7 +74,7 @@ def step_impl(context: Context, type_label: str, value_type: str):
 
 @step("attribute({type_label}) as({value_type}) get subtypes do not contain")
 def step_impl(context: Context, type_label: str, value_type: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = attribute_type_as_value_type(context, type_label, parse_value_type(value_type))
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_subtypes()))
     for sub_label in sub_labels:
@@ -115,7 +115,7 @@ def step_impl(context: Context, type_label: str, value_type):
 
 @step("attribute({type_label}) get key owners contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=True)))
     for owner_label in owner_labels:
@@ -124,7 +124,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=True)))
     for owner_label in owner_labels:
@@ -133,7 +133,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners explicit contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(
         map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
@@ -143,7 +143,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get key owners explicit do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(
         map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=True)))
@@ -153,7 +153,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=False)))
     for owner_label in owner_labels:
@@ -162,7 +162,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners(only_key=False)))
     for owner_label in owner_labels:
@@ -171,7 +171,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners explicit contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
     for owner_label in owner_labels:
@@ -180,7 +180,7 @@ def step_impl(context: Context, type_label: str):
 
 @step("attribute({type_label}) get attribute owners explicit do not contain")
 def step_impl(context: Context, type_label: str):
-    owner_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    owner_labels = [parse_label(s) for s in parse_list(context.table)]
     attribute_type = context.tx().concepts().get_attribute_type(type_label)
     actuals = list(map(lambda tt: tt.get_label(), attribute_type.as_remote(context.tx()).get_owners_explicit(only_key=False)))
     for owner_label in owner_labels:

--- a/tests/behaviour/concept/type/relationtype/relation_type_steps.py
+++ b/tests/behaviour/concept/type/relationtype/relation_type_steps.py
@@ -23,7 +23,7 @@ from behave import *
 from hamcrest import *
 
 from typedb.client import *
-from tests.behaviour.config.parameters import parse_list, parse_bool, parse_label
+from tests.behaviour.config.parameters import parse_list, parse_bool, parse_scoped_label
 from tests.behaviour.context import Context
 
 
@@ -113,7 +113,7 @@ def get_actual_related_role_scoped_labels(context: Context, relation_label: str)
 
 @step("relation({relation_label}) get related roles contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, has_item(role_label))
@@ -121,7 +121,7 @@ def step_impl(context: Context, relation_label: str):
 
 @step("relation({relation_label}) get related roles do not contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
@@ -133,7 +133,7 @@ def get_actual_related_role_explicit_scoped_labels(context: Context, relation_la
 
 @step("relation({relation_label}) get related explicit roles contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, has_item(role_label))
@@ -141,7 +141,7 @@ def step_impl(context: Context, relation_label: str):
 
 @step("relation({relation_label}) get related explicit roles do not contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
@@ -159,7 +159,7 @@ def get_actual_related_role_supertypes_scoped_labels(context: Context, relation_
 
 @step("relation({relation_label}) get role({role_label}) get supertypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, has_item(super_label))
@@ -167,7 +167,7 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 
 @step("relation({relation_label}) get role({role_label}) get supertypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, not_(has_item(super_label)))
@@ -179,7 +179,7 @@ def get_actual_related_role_players_scoped_labels(context: Context, relation_lab
 
 @step("relation({relation_label}) get role({role_label}) get players contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    player_labels = [parse_label(s) for s in parse_list(context.table)]
+    player_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, has_item(player_label))
@@ -187,7 +187,7 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 
 @step("relation({relation_label}) get role({role_label}) get players do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    player_labels = [parse_label(s) for s in parse_list(context.table)]
+    player_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, not_(has_item(player_label)))
@@ -199,7 +199,7 @@ def get_actual_related_role_subtypes_scoped_labels(context: Context, relation_la
 
 @step("relation({relation_label}) get role({role_label}) get subtypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, has_item(sub_label))
@@ -207,7 +207,7 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 
 @step("relation({relation_label}) get role({role_label}) get subtypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, not_(has_item(sub_label)))

--- a/tests/behaviour/concept/type/relationtype/relation_type_steps.py
+++ b/tests/behaviour/concept/type/relationtype/relation_type_steps.py
@@ -80,6 +80,12 @@ def step_impl(context: Context, relation_label: str, role_label: str, is_null):
     assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label) is None, is_(is_null))
 
 
+@step("relation({relation_label}) get overridden role({role_label}) is null: {is_null}")
+def step_impl(context: Context, relation_label: str, role_label: str, is_null):
+    is_null = parse_bool(is_null)
+    assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates_overridden(role_label) is None, is_(is_null))
+
+
 @step("relation({relation_label}) get role({role_label}) set label: {new_label}")
 def step_impl(context: Context, relation_label: str, role_label: str, new_label: str):
     context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).set_label(new_label)
@@ -88,6 +94,11 @@ def step_impl(context: Context, relation_label: str, role_label: str, new_label:
 @step("relation({relation_label}) get role({role_label}) get label: {get_label}")
 def step_impl(context: Context, relation_label: str, role_label: str, get_label: str):
     assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_label().name(), is_(get_label))
+
+
+@step("relation({relation_label}) get overridden role({role_label}) get label: {get_label}")
+def step_impl(context: Context, relation_label: str, role_label: str, get_label: str):
+    assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates_overridden(role_label).as_remote(context.tx()).get_label().name(), is_(get_label))
 
 
 @step("relation({relation_label}) get role({role_label}) is abstract: {is_abstract}")
@@ -112,6 +123,26 @@ def step_impl(context: Context, relation_label: str):
 def step_impl(context: Context, relation_label: str):
     role_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_related_role_scoped_labels(context, relation_label)
+    for role_label in role_labels:
+        assert_that(actuals, not_(has_item(role_label)))
+
+
+def get_actual_related_role_explicit_scoped_labels(context: Context, relation_label: str):
+    return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates_explicit()]
+
+
+@step("relation({relation_label}) get related explicit roles contain")
+def step_impl(context: Context, relation_label: str):
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
+    for role_label in role_labels:
+        assert_that(actuals, has_item(role_label))
+
+
+@step("relation({relation_label}) get related explicit roles do not contain")
+def step_impl(context: Context, relation_label: str):
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
 

--- a/tests/behaviour/concept/type/relationtype/relation_type_steps.py
+++ b/tests/behaviour/concept/type/relationtype/relation_type_steps.py
@@ -23,7 +23,7 @@ from behave import *
 from hamcrest import *
 
 from typedb.client import *
-from tests.behaviour.config.parameters import parse_list, parse_bool, parse_scoped_label
+from tests.behaviour.config.parameters import parse_list, parse_bool, parse_label
 from tests.behaviour.context import Context
 
 
@@ -107,42 +107,42 @@ def step_impl(context: Context, relation_label: str, role_label: str, is_abstrac
     assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).is_abstract(), is_(is_abstract))
 
 
-def get_actual_related_role_scoped_labels(context: Context, relation_label: str):
+def get_actual_related_role_labels(context: Context, relation_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates()]
 
 
 @step("relation({relation_label}) get related roles contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_scoped_labels(context, relation_label)
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, has_item(role_label))
 
 
 @step("relation({relation_label}) get related roles do not contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_scoped_labels(context, relation_label)
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
 
 
-def get_actual_related_role_explicit_scoped_labels(context: Context, relation_label: str):
+def get_actual_related_role_explicit_labels(context: Context, relation_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates_explicit()]
 
 
 @step("relation({relation_label}) get related explicit roles contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_explicit_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, has_item(role_label))
 
 
 @step("relation({relation_label}) get related explicit roles do not contain")
 def step_impl(context: Context, relation_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_explicit_scoped_labels(context, relation_label)
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_explicit_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
 
@@ -153,61 +153,61 @@ def step_impl(context: Context, relation_label: str, role_label: str, super_labe
     assert_that(supertype, is_(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_supertype()))
 
 
-def get_actual_related_role_supertypes_scoped_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_supertypes_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_supertypes()]
 
 
 @step("relation({relation_label}) get role({role_label}) get supertypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_supertypes_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, has_item(super_label))
 
 
 @step("relation({relation_label}) get role({role_label}) get supertypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_supertypes_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, not_(has_item(super_label)))
 
 
-def get_actual_related_role_players_scoped_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_players_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_players()]
 
 
 @step("relation({relation_label}) get role({role_label}) get players contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    player_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
+    player_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_players_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, has_item(player_label))
 
 
 @step("relation({relation_label}) get role({role_label}) get players do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    player_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
+    player_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_players_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, not_(has_item(player_label)))
 
 
-def get_actual_related_role_subtypes_scoped_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_subtypes_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_subtypes()]
 
 
 @step("relation({relation_label}) get role({role_label}) get subtypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_subtypes_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, has_item(sub_label))
 
 
 @step("relation({relation_label}) get role({role_label}) get subtypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_related_role_subtypes_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, not_(has_item(sub_label)))

--- a/tests/behaviour/concept/type/relationtype/relation_type_steps.py
+++ b/tests/behaviour/concept/type/relationtype/relation_type_steps.py
@@ -107,14 +107,14 @@ def step_impl(context: Context, relation_label: str, role_label: str, is_abstrac
     assert_that(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).is_abstract(), is_(is_abstract))
 
 
-def get_actual_related_role_labels(context: Context, relation_label: str):
+def get_actual_related_role_scoped_labels(context: Context, relation_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates()]
 
 
 @step("relation({relation_label}) get related roles contain")
 def step_impl(context: Context, relation_label: str):
     role_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_labels(context, relation_label)
+    actuals = get_actual_related_role_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, has_item(role_label))
 
@@ -122,7 +122,7 @@ def step_impl(context: Context, relation_label: str):
 @step("relation({relation_label}) get related roles do not contain")
 def step_impl(context: Context, relation_label: str):
     role_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_labels(context, relation_label)
+    actuals = get_actual_related_role_scoped_labels(context, relation_label)
     for role_label in role_labels:
         assert_that(actuals, not_(has_item(role_label)))
 
@@ -153,14 +153,14 @@ def step_impl(context: Context, relation_label: str, role_label: str, super_labe
     assert_that(supertype, is_(context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_supertype()))
 
 
-def get_actual_related_role_supertypes_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_supertypes_scoped_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_supertypes()]
 
 
 @step("relation({relation_label}) get role({role_label}) get supertypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     super_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_supertypes_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, has_item(super_label))
 
@@ -168,19 +168,19 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 @step("relation({relation_label}) get role({role_label}) get supertypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     super_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_supertypes_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_supertypes_scoped_labels(context, relation_label, role_label)
     for super_label in super_labels:
         assert_that(actuals, not_(has_item(super_label)))
 
 
-def get_actual_related_role_players_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_players_scoped_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_players()]
 
 
 @step("relation({relation_label}) get role({role_label}) get players contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     player_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_players_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, has_item(player_label))
 
@@ -188,19 +188,19 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 @step("relation({relation_label}) get role({role_label}) get players do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     player_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_players_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_players_scoped_labels(context, relation_label, role_label)
     for player_label in player_labels:
         assert_that(actuals, not_(has_item(player_label)))
 
 
-def get_actual_related_role_subtypes_labels(context: Context, relation_label: str, role_label: str):
+def get_actual_related_role_subtypes_scoped_labels(context: Context, relation_label: str, role_label: str):
     return [r.get_label() for r in context.tx().concepts().get_relation_type(relation_label).as_remote(context.tx()).get_relates(role_label).as_remote(context.tx()).get_subtypes()]
 
 
 @step("relation({relation_label}) get role({role_label}) get subtypes contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     sub_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_subtypes_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, has_item(sub_label))
 
@@ -208,6 +208,6 @@ def step_impl(context: Context, relation_label: str, role_label: str):
 @step("relation({relation_label}) get role({role_label}) get subtypes do not contain")
 def step_impl(context: Context, relation_label: str, role_label: str):
     sub_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = get_actual_related_role_subtypes_labels(context, relation_label, role_label)
+    actuals = get_actual_related_role_subtypes_scoped_labels(context, relation_label, role_label)
     for sub_label in sub_labels:
         assert_that(actuals, not_(has_item(sub_label)))

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -51,7 +51,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
     context.get_thing_type(root_label, type_label).as_remote(context.tx()).delete()
 
 
-@step("{root_label:RootLabel}({type_label}) is null: {is_null}")
+@step("{root_label:RootLabel}({type_label:Label}) is null: {is_null}")
 def step_impl(context: Context, root_label: RootLabel, type_label: str, is_null):
     is_null = parse_bool(is_null)
     assert_that(context.get_thing_type(root_label, type_label) is None, is_(is_null))

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -22,7 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_label
+from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_scoped_label
 from tests.behaviour.context import Context
 from typedb.client import *
 
@@ -62,7 +62,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, new_labe
     context.get_thing_type(root_label, type_label).as_remote(context.tx()).set_label(new_label)
 
 
-@step("{root_label:RootLabel}({type_label}) get label: {get_label}")
+@step("{root_label:RootLabel}({type_label:Label}) get label: {get_label}")
 def step_impl(context: Context, root_label: RootLabel, type_label: str, get_label: str):
     assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_label().name(), is_(get_label))
 
@@ -147,7 +147,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, super_la
 
 @step("{root_label:RootLabel}({type_label}) get supertypes contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(actuals, has_item(super_label))
@@ -155,7 +155,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get supertypes do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(actuals, not_(has_item(super_label)))
@@ -163,7 +163,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get subtypes contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(actuals, has_item(sub_label))
@@ -171,7 +171,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get subtypes do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(actuals, not_(has_item(sub_label)))
@@ -235,7 +235,7 @@ def get_actual_owns_key_types(context: Context, root_label: RootLabel, type_labe
 
 @step("{root_label:RootLabel}({type_label}) get owns key types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -243,7 +243,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns key types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -255,7 +255,7 @@ def get_actual_owns_explicit_key_types(context: Context, root_label: RootLabel, 
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit key types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -263,7 +263,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit key types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -309,7 +309,7 @@ def get_actual_owns(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns attribute types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -317,7 +317,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns attribute types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -329,7 +329,7 @@ def get_actual_owns_explicit(context: Context, root_label: RootLabel, type_label
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit attribute types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -337,7 +337,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit attribute types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -412,7 +412,7 @@ def get_actual_plays(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, is_in(actuals))
@@ -420,7 +420,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, not_(is_in(actuals)))
@@ -432,7 +432,7 @@ def get_actual_plays_explicit(context: Context, root_label: RootLabel, type_labe
 
 @step("{root_label:RootLabel}({type_label}) get playing roles explicit contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays_explicit(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, is_in(actuals))
@@ -440,7 +440,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles explicit do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays_explicit(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, not_(is_in(actuals)))
@@ -448,7 +448,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("thing type root get supertypes contain")
 def step_impl(context: Context):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(super_label, is_in(actuals))
@@ -456,7 +456,7 @@ def step_impl(context: Context):
 
 @step("thing type root get supertypes do not contain")
 def step_impl(context: Context):
-    super_labels = [parse_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(super_label, not_(is_in(actuals)))
@@ -464,7 +464,7 @@ def step_impl(context: Context):
 
 @step("thing type root get subtypes contain")
 def step_impl(context: Context):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(sub_label, is_in(actuals))
@@ -472,7 +472,7 @@ def step_impl(context: Context):
 
 @step("thing type root get subtypes do not contain")
 def step_impl(context: Context):
-    sub_labels = [parse_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(sub_label, not_(is_in(actuals)))

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -343,17 +343,17 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
         assert_that(actuals, not_(has_item(attribute_label)))
 
 
-@step("{root_label:RootLabel}({type_label}) get owns overridden attribute({attr_type_label}) is null: {is_null}")
-def step_impl(context: Context, root_label: RootLabel, type_label: str, attr_type_label: str, is_null):
+@step("{root_label:RootLabel}({type_label:Label}) get owns overridden attribute({attr_type_label}) is null: {is_null}")
+def step_impl(context: Context, root_label: RootLabel, type_label: Label, attr_type_label: str, is_null):
     is_null = parse_bool(is_null)
     attribute_type = context.tx().concepts().get_attribute_type(attr_type_label)
-    assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_overridden(attribute_type) is None, is_(is_null))
+    assert_that(context.get_thing_type(root_label, type_label.name()).as_remote(context.tx()).get_owns_overridden(attribute_type) is None, is_(is_null))
 
 
-@step("{root_label:RootLabel}({type_label}) get owns overridden attribute({attr_type_label}) get label: {label}")
-def step_impl(context: Context, root_label: RootLabel, type_label: str, attr_type_label: str, label: str):
+@step("{root_label:RootLabel}({type_label:Label}) get owns overridden attribute({attr_type_label}) get label: {label}")
+def step_impl(context: Context, root_label: RootLabel, type_label: Label, attr_type_label: str, label: str):
     attribute_type = context.tx().concepts().get_attribute_type(attr_type_label)
-    assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_overridden(attribute_type).get_label().name(), is_(label))
+    assert_that(context.get_thing_type(root_label, type_label.name()).as_remote(context.tx()).get_owns_overridden(attribute_type).get_label().name(), is_(label))
 
 
 @step("{root_label:RootLabel}({type_label}) set plays role: {role_label:ScopedLabel} as {overridden_label:ScopedLabel}; throws exception")

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -22,7 +22,7 @@
 from behave import *
 from hamcrest import *
 
-from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_scoped_label
+from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_label
 from tests.behaviour.context import Context
 from typedb.client import *
 
@@ -52,9 +52,9 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 
 @step("{root_label:RootLabel}({type_label:Label}) is null: {is_null}")
-def step_impl(context: Context, root_label: RootLabel, type_label: str, is_null):
+def step_impl(context: Context, root_label: RootLabel, type_label: Label, is_null):
     is_null = parse_bool(is_null)
-    assert_that(context.get_thing_type(root_label, type_label) is None, is_(is_null))
+    assert_that(context.get_thing_type(root_label, type_label.name()) is None, is_(is_null))
 
 
 @step("{root_label:RootLabel}({type_label}) set label: {new_label}")
@@ -63,8 +63,8 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, new_labe
 
 
 @step("{root_label:RootLabel}({type_label:Label}) get label: {get_label}")
-def step_impl(context: Context, root_label: RootLabel, type_label: str, get_label: str):
-    assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_label().name(), is_(get_label))
+def step_impl(context: Context, root_label: RootLabel, type_label: Label, get_label: str):
+    assert_that(context.get_thing_type(root_label, type_label.name()).as_remote(context.tx()).get_label().name(), is_(get_label))
 
 
 @step("{root_label:RootLabel}({type_label}) set abstract: {is_abstract}; throws exception")
@@ -147,7 +147,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, super_la
 
 @step("{root_label:RootLabel}({type_label}) get supertypes contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(actuals, has_item(super_label))
@@ -155,7 +155,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get supertypes do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(actuals, not_(has_item(super_label)))
@@ -163,7 +163,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get subtypes contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(actuals, has_item(sub_label))
@@ -171,7 +171,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get subtypes do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(actuals, not_(has_item(sub_label)))
@@ -235,7 +235,7 @@ def get_actual_owns_key_types(context: Context, root_label: RootLabel, type_labe
 
 @step("{root_label:RootLabel}({type_label}) get owns key types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -243,7 +243,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns key types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -255,7 +255,7 @@ def get_actual_owns_explicit_key_types(context: Context, root_label: RootLabel, 
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit key types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -263,7 +263,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit key types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -309,7 +309,7 @@ def get_actual_owns(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns attribute types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -317,7 +317,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns attribute types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -329,7 +329,7 @@ def get_actual_owns_explicit(context: Context, root_label: RootLabel, type_label
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit attribute types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
@@ -337,7 +337,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get owns explicit attribute types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    attribute_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_owns_explicit(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
@@ -412,7 +412,7 @@ def get_actual_plays(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, is_in(actuals))
@@ -420,7 +420,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, not_(is_in(actuals)))
@@ -432,7 +432,7 @@ def get_actual_plays_explicit(context: Context, root_label: RootLabel, type_labe
 
 @step("{root_label:RootLabel}({type_label}) get playing roles explicit contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays_explicit(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, is_in(actuals))
@@ -440,7 +440,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("{root_label:RootLabel}({type_label}) get playing roles explicit do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
-    role_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = get_actual_plays_explicit(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, not_(is_in(actuals)))
@@ -448,7 +448,7 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 
 @step("thing type root get supertypes contain")
 def step_impl(context: Context):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(super_label, is_in(actuals))
@@ -456,7 +456,7 @@ def step_impl(context: Context):
 
 @step("thing type root get supertypes do not contain")
 def step_impl(context: Context):
-    super_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    super_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_supertypes()]
     for super_label in super_labels:
         assert_that(super_label, not_(is_in(actuals)))
@@ -464,7 +464,7 @@ def step_impl(context: Context):
 
 @step("thing type root get subtypes contain")
 def step_impl(context: Context):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(sub_label, is_in(actuals))
@@ -472,7 +472,7 @@ def step_impl(context: Context):
 
 @step("thing type root get subtypes do not contain")
 def step_impl(context: Context):
-    sub_labels = [parse_scoped_label(s) for s in parse_list(context.table)]
+    sub_labels = [parse_label(s) for s in parse_list(context.table)]
     actuals = [t.get_label() for t in context.tx().concepts().get_root_thing_type().as_remote(context.tx()).get_subtypes()]
     for sub_label in sub_labels:
         assert_that(sub_label, not_(is_in(actuals)))

--- a/tests/behaviour/concept/type/thingtype/thing_type_steps.py
+++ b/tests/behaviour/concept/type/thingtype/thing_type_steps.py
@@ -22,9 +22,9 @@
 from behave import *
 from hamcrest import *
 
-from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, parse_list, RootLabel, parse_label
 from tests.behaviour.context import Context
+from typedb.client import *
 
 
 @step("put {root_label:RootLabel} type: {type_label}")
@@ -229,10 +229,14 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, att_type
     context.get_thing_type(root_label, type_label).as_remote(context.tx()).unset_owns(attribute_type)
 
 
+def get_actual_owns_key_types(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns(keys_only=True)]
+
+
 @step("{root_label:RootLabel}({type_label}) get owns key types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     attribute_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns(keys_only=True)]
+    actuals = get_actual_owns_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
 
@@ -240,7 +244,27 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 @step("{root_label:RootLabel}({type_label}) get owns key types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     attribute_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns(keys_only=True)]
+    actuals = get_actual_owns_key_types(context, root_label, type_label)
+    for attribute_label in attribute_labels:
+        assert_that(actuals, not_(has_item(attribute_label)))
+
+
+def get_actual_owns_explicit_key_types(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_explicit(keys_only=True)]
+
+
+@step("{root_label:RootLabel}({type_label}) get owns explicit key types contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
+    for attribute_label in attribute_labels:
+        assert_that(actuals, has_item(attribute_label))
+
+
+@step("{root_label:RootLabel}({type_label}) get owns explicit key types do not contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_owns_explicit_key_types(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
 
@@ -279,10 +303,14 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, att_type
     context.get_thing_type(root_label, type_label).as_remote(context.tx()).set_owns(attribute_type)
 
 
+def get_actual_owns(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns()]
+
+
 @step("{root_label:RootLabel}({type_label}) get owns attribute types contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     attribute_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns()]
+    actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, has_item(attribute_label))
 
@@ -290,9 +318,42 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 @step("{root_label:RootLabel}({type_label}) get owns attribute types do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     attribute_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns()]
+    actuals = get_actual_owns(context, root_label, type_label)
     for attribute_label in attribute_labels:
         assert_that(actuals, not_(has_item(attribute_label)))
+
+
+def get_actual_owns_explicit(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_explicit()]
+
+
+@step("{root_label:RootLabel}({type_label}) get owns explicit attribute types contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_owns_explicit(context, root_label, type_label)
+    for attribute_label in attribute_labels:
+        assert_that(actuals, has_item(attribute_label))
+
+
+@step("{root_label:RootLabel}({type_label}) get owns explicit attribute types do not contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    attribute_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_owns_explicit(context, root_label, type_label)
+    for attribute_label in attribute_labels:
+        assert_that(actuals, not_(has_item(attribute_label)))
+
+
+@step("{root_label:RootLabel}({type_label}) get owns overridden attribute({attr_type_label}) is null: {is_null}")
+def step_impl(context: Context, root_label: RootLabel, type_label: str, attr_type_label: str, is_null):
+    is_null = parse_bool(is_null)
+    attribute_type = context.tx().concepts().get_attribute_type(attr_type_label)
+    assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_overridden(attribute_type) is None, is_(is_null))
+
+
+@step("{root_label:RootLabel}({type_label}) get owns overridden attribute({attr_type_label}) get label: {label}")
+def step_impl(context: Context, root_label: RootLabel, type_label: str, attr_type_label: str, label: str):
+    attribute_type = context.tx().concepts().get_attribute_type(attr_type_label)
+    assert_that(context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_owns_overridden(attribute_type).get_label().name(), is_(label))
 
 
 @step("{root_label:RootLabel}({type_label}) set plays role: {role_label:ScopedLabel} as {overridden_label:ScopedLabel}; throws exception")
@@ -345,10 +406,14 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str, role_lab
     context.get_thing_type(root_label, type_label).as_remote(context.tx()).unset_plays(role_type)
 
 
+def get_actual_plays(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_plays()]
+
+
 @step("{root_label:RootLabel}({type_label}) get playing roles contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     role_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_plays()]
+    actuals = get_actual_plays(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, is_in(actuals))
 
@@ -356,7 +421,27 @@ def step_impl(context: Context, root_label: RootLabel, type_label: str):
 @step("{root_label:RootLabel}({type_label}) get playing roles do not contain")
 def step_impl(context: Context, root_label: RootLabel, type_label: str):
     role_labels = [parse_label(s) for s in parse_list(context.table)]
-    actuals = [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_plays()]
+    actuals = get_actual_plays(context, root_label, type_label)
+    for role_label in role_labels:
+        assert_that(role_label, not_(is_in(actuals)))
+
+
+def get_actual_plays_explicit(context: Context, root_label: RootLabel, type_label: str):
+    return [t.get_label() for t in context.get_thing_type(root_label, type_label).as_remote(context.tx()).get_plays_explicit()]
+
+
+@step("{root_label:RootLabel}({type_label}) get playing roles explicit contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_plays_explicit(context, root_label, type_label)
+    for role_label in role_labels:
+        assert_that(role_label, is_in(actuals))
+
+
+@step("{root_label:RootLabel}({type_label}) get playing roles explicit do not contain")
+def step_impl(context: Context, root_label: RootLabel, type_label: str):
+    role_labels = [parse_label(s) for s in parse_list(context.table)]
+    actuals = get_actual_plays_explicit(context, root_label, type_label)
     for role_label in role_labels:
         assert_that(role_label, not_(is_in(actuals)))
 

--- a/tests/behaviour/config/parameters.py
+++ b/tests/behaviour/config/parameters.py
@@ -85,12 +85,20 @@ register_type(RootLabel=parse_root_label)
 
 
 @parse.with_pattern(r"[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+")
-def parse_label(text: str) -> Label:
+def parse_scoped_label(text: str) -> Label:
     fragments = text.split(":")
     return Label.of(*fragments) if len(fragments) == 2 else Label.of(fragments[0])
 
 
-register_type(ScopedLabel=parse_label)
+register_type(ScopedLabel=parse_scoped_label)
+
+
+@parse.with_pattern(r"[a-zA-Z0-9]+")
+def parse_label(text: str):
+    return text
+
+
+register_type(Label=parse_label)
 
 
 @parse.with_pattern(r"\$([a-zA-Z0-9]+)")

--- a/tests/behaviour/config/parameters.py
+++ b/tests/behaviour/config/parameters.py
@@ -86,16 +86,15 @@ register_type(RootLabel=parse_root_label)
 
 @parse.with_pattern(r"[a-zA-Z0-9-_]+:[a-zA-Z0-9-_]+")
 def parse_scoped_label(text: str) -> Label:
-    fragments = text.split(":")
-    return Label.of(*fragments) if len(fragments) == 2 else Label.of(fragments[0])
+    return parse_label(text)
 
 
 register_type(ScopedLabel=parse_scoped_label)
 
 
-@parse.with_pattern(r"[a-zA-Z0-9]+")
+@parse.with_pattern(r"[a-zA-Z0-9:]+")
 def parse_label(text: str):
-    return text
+    return Label.of(*text.split(":"))
 
 
 register_type(Label=parse_label)

--- a/tests/behaviour/typeql/typeql_steps.py
+++ b/tests/behaviour/typeql/typeql_steps.py
@@ -26,7 +26,7 @@ from hamcrest import *
 
 from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, parse_int, parse_float, parse_datetime, parse_table, \
-    parse_label
+    parse_scoped_label
 from tests.behaviour.context import Context
 
 
@@ -198,7 +198,7 @@ class ConceptMatcher(ABC):
 class TypeLabelMatcher(ConceptMatcher):
 
     def __init__(self, label: str):
-        self.label = parse_label(label)
+        self.label = parse_scoped_label(label)
 
     def match(self, context: Context, concept: Concept):
         if concept.is_type():

--- a/tests/behaviour/typeql/typeql_steps.py
+++ b/tests/behaviour/typeql/typeql_steps.py
@@ -26,7 +26,7 @@ from hamcrest import *
 
 from typedb.client import *
 from tests.behaviour.config.parameters import parse_bool, parse_int, parse_float, parse_datetime, parse_table, \
-    parse_scoped_label
+    parse_label
 from tests.behaviour.context import Context
 
 
@@ -198,7 +198,7 @@ class ConceptMatcher(ABC):
 class TypeLabelMatcher(ConceptMatcher):
 
     def __init__(self, label: str):
-        self.label = parse_scoped_label(label)
+        self.label = parse_label(label)
 
     def match(self, context: Context, concept: Concept):
         if concept.is_type():

--- a/typedb/api/concept/type/attribute_type.py
+++ b/typedb/api/concept/type/attribute_type.py
@@ -117,6 +117,10 @@ class RemoteAttributeType(RemoteThingType, AttributeType, ABC):
         pass
 
     @abstractmethod
+    def get_owners_explicit(self, only_key: bool = False) -> Iterator[ThingType]:
+        pass
+
+    @abstractmethod
     def as_boolean(self) -> "RemoteBooleanAttributeType":
         pass
 

--- a/typedb/api/concept/type/relation_type.py
+++ b/typedb/api/concept/type/relation_type.py
@@ -19,7 +19,7 @@
 # under the License.
 #
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, Union
+from typing import TYPE_CHECKING, Iterator, Union, Optional
 
 from typedb.api.concept.thing.relation import Relation
 from typedb.api.concept.type.role_type import RoleType
@@ -58,7 +58,7 @@ class RemoteRelationType(RemoteThingType, RelationType, ABC):
         pass
 
     @abstractmethod
-    def get_relates_overridden(self, role_label: str) -> Union[None, "RoleType"]:
+    def get_relates_overridden(self, role_label: str) -> Optional["RoleType"]:
         pass
 
     @abstractmethod

--- a/typedb/api/concept/type/relation_type.py
+++ b/typedb/api/concept/type/relation_type.py
@@ -50,7 +50,15 @@ class RemoteRelationType(RemoteThingType, RelationType, ABC):
         pass
 
     @abstractmethod
-    def get_relates(self, role_label: str = None) -> Union[RoleType, Iterator[RoleType]]:
+    def get_relates(self, role_label: str = None) -> Union["RoleType", Iterator["RoleType"]]:
+        pass
+
+    @abstractmethod
+    def get_relates_explicit(self) -> Iterator["RoleType"]:
+        pass
+
+    @abstractmethod
+    def get_relates_overridden(self, role_label: str) -> Union[None, "RoleType"]:
         pass
 
     @abstractmethod
@@ -62,9 +70,9 @@ class RemoteRelationType(RemoteThingType, RelationType, ABC):
         pass
 
     @abstractmethod
-    def get_subtypes(self) -> Iterator[RelationType]:
+    def get_subtypes(self) -> Iterator["RelationType"]:
         pass
 
     @abstractmethod
-    def set_supertype(self, relation_type: RelationType) -> None:
+    def set_supertype(self, relation_type: "RelationType") -> None:
         pass

--- a/typedb/api/concept/type/thing_type.py
+++ b/typedb/api/concept/type/thing_type.py
@@ -19,11 +19,11 @@
 # under the License.
 #
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, Union, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from typedb.api.concept.thing.thing import Thing
-from typedb.api.concept.type.type import Type, RemoteType
 from typedb.api.concept.type.role_type import RoleType
+from typedb.api.concept.type.type import Type, RemoteType
 
 if TYPE_CHECKING:
     from typedb.api.concept.type.attribute_type import AttributeType

--- a/typedb/api/concept/type/thing_type.py
+++ b/typedb/api/concept/type/thing_type.py
@@ -19,7 +19,7 @@
 # under the License.
 #
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Union
 
 from typedb.api.concept.thing.thing import Thing
 from typedb.api.concept.type.type import Type, RemoteType
@@ -75,11 +75,27 @@ class RemoteThingType(RemoteType, ThingType, ABC):
         pass
 
     @abstractmethod
-    def get_plays(self) -> Iterator[RoleType]:
+    def get_plays(self) -> Iterator["RoleType"]:
+        pass
+
+    @abstractmethod
+    def get_plays_explicit(self) -> Iterator["RoleType"]:
+        pass
+
+    @abstractmethod
+    def get_plays_overridden(self, role_type: "RoleType") -> Union[None, "RoleType"]:
         pass
 
     @abstractmethod
     def get_owns(self, value_type: "AttributeType.ValueType" = None, keys_only: bool = False) -> Iterator["AttributeType"]:
+        pass
+
+    @abstractmethod
+    def get_owns_explicit(self, value_type: "AttributeType.ValueType" = None, keys_only: bool = False) -> Iterator["AttributeType"]:
+        pass
+
+    @abstractmethod
+    def get_owns_overridden(self, attribute_type: "AttributeType") -> Union[None, "AttributeType"]:
         pass
 
     @abstractmethod

--- a/typedb/api/concept/type/thing_type.py
+++ b/typedb/api/concept/type/thing_type.py
@@ -19,7 +19,7 @@
 # under the License.
 #
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, Union
+from typing import TYPE_CHECKING, Iterator, Union, Optional
 
 from typedb.api.concept.thing.thing import Thing
 from typedb.api.concept.type.type import Type, RemoteType
@@ -83,7 +83,7 @@ class RemoteThingType(RemoteType, ThingType, ABC):
         pass
 
     @abstractmethod
-    def get_plays_overridden(self, role_type: "RoleType") -> Union[None, "RoleType"]:
+    def get_plays_overridden(self, role_type: "RoleType") -> Optional["RoleType"]:
         pass
 
     @abstractmethod
@@ -95,7 +95,7 @@ class RemoteThingType(RemoteType, ThingType, ABC):
         pass
 
     @abstractmethod
-    def get_owns_overridden(self, attribute_type: "AttributeType") -> Union[None, "AttributeType"]:
+    def get_owns_overridden(self, attribute_type: "AttributeType") -> Optional["AttributeType"]:
         pass
 
     @abstractmethod

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -462,6 +462,20 @@ def thing_type_get_plays_req(label: Label):
     return type_req(req, label)
 
 
+def thing_type_get_plays_explicit_req(label: Label):
+    req = concept_proto.Type.Req()
+    req.thing_type_get_plays_explicit_req.CopyFrom(concept_proto.ThingType.GetPlaysExplicit.Req())
+    return type_req(req, label)
+
+
+def thing_type_get_plays_overridden(label: Label, role_type: concept_proto.Type):
+    req = concept_proto.Type.Req()
+    get_plays_overridden_req = concept_proto.Type.GetPlaysOverridden.Req()
+    get_plays_overridden_req.role_type = role_type
+    req.thing_type_get_plays_overridden_req.CopyFrom(get_plays_overridden_req)
+    return type_req(req, label)
+
+
 def thing_type_set_plays_req(label: Label, role_type: concept_proto.Type, overridden_role_type: concept_proto.Type = None):
     req = concept_proto.Type.Req()
     set_plays_req = concept_proto.ThingType.SetPlays.Req()
@@ -487,6 +501,24 @@ def thing_type_get_owns_req(label: Label, value_type: concept_proto.AttributeTyp
     if value_type:
         get_owns_req.value_type = value_type
     req.thing_type_get_owns_req.CopyFrom(get_owns_req)
+    return type_req(req, label)
+
+
+def thing_type_get_owns_explicit_req(label: Label, value_type: concept_proto.AttributeType.ValueType = None, keys_only: bool = False):
+    req = concept_proto.Type.Req()
+    get_owns_explicit_req = concept_proto.ThingType.GetOwnsExplicit.Req()
+    get_owns_explicit_req.keys_only = keys_only
+    if value_type:
+        get_owns_explicit_req.value_type = value_type
+    req.thing_type_get_owns_explicit_req.CopyFrom(get_owns_explicit_req)
+    return type_req(req, label)
+
+
+def thing_type_get_owns_overridden_req(label: Label, attribute_type: concept_proto.Type):
+    req = concept_proto.Type.Req()
+    get_owns_overridden_req = concept_proto.ThingType.GetOwnsOverridden.Req()
+    get_owns_overridden_req.attribute_type = attribute_type
+    req.thing_type_get_owns_overridden_req.CopyFrom(get_owns_overridden_req)
     return type_req(req, label)
 
 
@@ -544,6 +576,19 @@ def relation_type_get_relates_req(label: Label, role_label: str = None):
     return type_req(req, label)
 
 
+def relation_type_get_relates_explicit_req(label: Label):
+    req = concept_proto.Type.Req()
+    req.relation_type_get_relates_explicit_req.CopyFrom(concept_proto.RelationType.GetRelatesExplicit.Req())
+    return type_req(req, label)
+
+def relation_type_get_relates_overridden_req(label: Label, role_label: str):
+    type_req = concept_proto.Type.Req()
+    get_relates_overridden_req = concept_proto.RelationType.GetRelatesOverridden.Req()
+    get_relates_overridden_req.label = role_label
+    type_req.relation_type_gets_relates_overridden_req.CopyFrom(get_relates_overridden_req)
+    return type_req(type_req, label)
+
+
 def relation_type_set_relates_req(label: Label, role_label: str, overridden_label: str = None):
     req = concept_proto.Type.Req()
     set_relates_req = concept_proto.RelationType.SetRelates.Req()
@@ -569,6 +614,14 @@ def attribute_type_get_owners_req(label: Label, only_key: bool = False):
     get_owners_req = concept_proto.AttributeType.GetOwners.Req()
     get_owners_req.only_key = only_key
     req.attribute_type_get_owners_req.CopyFrom(get_owners_req)
+    return type_req(req, label)
+
+
+def attribute_type_get_owners_explicit_req(label: Label, only_key: bool = False):
+    req = concept_proto.Type.Req()
+    get_owners_explicit_req = concept_proto.AttributeType.GetOwnersExplicit.Req()
+    get_owners_explicit_req.only_key = only_key
+    req.attribute_type_get_owners_explicit_req.CopyFrom(get_owners_explicit_req)
     return type_req(req, label)
 
 

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -82,6 +82,7 @@ def cluster_database_manager_get_req(name: str):
     req.name = name
     return req
 
+
 def cluster_database_manager_all_req():
     return cluster_database_proto.ClusterDatabaseManager.All.Req()
 
@@ -91,11 +92,13 @@ def cluster_database_manager_all_req():
 def cluster_user_manager_all_req():
     return cluster_user_proto.ClusterUserManager.All.Req()
 
+
 def cluster_user_manager_create_req(username: str, password: str):
     req = cluster_user_proto.ClusterUserManager.Create.Req()
     req.username = username
     req.password = password
     return req
+
 
 def cluster_user_manager_contains_req(username: str):
     req = cluster_user_proto.ClusterUserManager.Contains.Req()
@@ -111,10 +114,12 @@ def cluster_user_password_req(username: str, password: str):
     req.password = password
     return req
 
+
 def cluster_user_token_req(username: str):
     req = cluster_user_proto.ClusterUser.Token.Req()
     req.username = username
     return req
+
 
 def cluster_user_delete_req(username: str):
     req = cluster_user_proto.ClusterUser.Delete.Req()
@@ -471,12 +476,13 @@ def thing_type_get_plays_explicit_req(label: Label):
 def thing_type_get_plays_overridden(label: Label, role_type: concept_proto.Type):
     req = concept_proto.Type.Req()
     get_plays_overridden_req = concept_proto.Type.GetPlaysOverridden.Req()
-    get_plays_overridden_req.role_type = role_type
+    get_plays_overridden_req.role_type.CopyFrom(role_type)
     req.thing_type_get_plays_overridden_req.CopyFrom(get_plays_overridden_req)
     return type_req(req, label)
 
 
-def thing_type_set_plays_req(label: Label, role_type: concept_proto.Type, overridden_role_type: concept_proto.Type = None):
+def thing_type_set_plays_req(label: Label, role_type: concept_proto.Type,
+                             overridden_role_type: concept_proto.Type = None):
     req = concept_proto.Type.Req()
     set_plays_req = concept_proto.ThingType.SetPlays.Req()
     set_plays_req.role_type.CopyFrom(role_type)
@@ -494,7 +500,8 @@ def thing_type_unset_plays_req(label: Label, role_type: concept_proto.Type):
     return type_req(req, label)
 
 
-def thing_type_get_owns_req(label: Label, value_type: concept_proto.AttributeType.ValueType = None, keys_only: bool = False):
+def thing_type_get_owns_req(label: Label, value_type: concept_proto.AttributeType.ValueType = None,
+                            keys_only: bool = False):
     req = concept_proto.Type.Req()
     get_owns_req = concept_proto.ThingType.GetOwns.Req()
     get_owns_req.keys_only = keys_only
@@ -504,7 +511,8 @@ def thing_type_get_owns_req(label: Label, value_type: concept_proto.AttributeTyp
     return type_req(req, label)
 
 
-def thing_type_get_owns_explicit_req(label: Label, value_type: concept_proto.AttributeType.ValueType = None, keys_only: bool = False):
+def thing_type_get_owns_explicit_req(label: Label, value_type: concept_proto.AttributeType.ValueType = None,
+                                     keys_only: bool = False):
     req = concept_proto.Type.Req()
     get_owns_explicit_req = concept_proto.ThingType.GetOwnsExplicit.Req()
     get_owns_explicit_req.keys_only = keys_only
@@ -522,7 +530,8 @@ def thing_type_get_owns_overridden_req(label: Label, attribute_type: concept_pro
     return type_req(req, label)
 
 
-def thing_type_set_owns_req(label: Label, attribute_type: concept_proto.Type, overridden_type: concept_proto.Type = None, is_key: bool = False):
+def thing_type_set_owns_req(label: Label, attribute_type: concept_proto.Type,
+                            overridden_type: concept_proto.Type = None, is_key: bool = False):
     req = concept_proto.Type.Req()
     set_owns_req = concept_proto.ThingType.SetOwns.Req()
     set_owns_req.attribute_type.CopyFrom(attribute_type)
@@ -581,12 +590,13 @@ def relation_type_get_relates_explicit_req(label: Label):
     req.relation_type_get_relates_explicit_req.CopyFrom(concept_proto.RelationType.GetRelatesExplicit.Req())
     return type_req(req, label)
 
+
 def relation_type_get_relates_overridden_req(label: Label, role_label: str):
-    type_req = concept_proto.Type.Req()
+    req = concept_proto.Type.Req()
     get_relates_overridden_req = concept_proto.RelationType.GetRelatesOverridden.Req()
     get_relates_overridden_req.label = role_label
-    type_req.relation_type_gets_relates_overridden_req.CopyFrom(get_relates_overridden_req)
-    return type_req(type_req, label)
+    req.relation_type_gets_relates_overridden_req.CopyFrom(get_relates_overridden_req)
+    return req(req, label)
 
 
 def relation_type_set_relates_req(label: Label, role_label: str, overridden_label: str = None):

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -465,9 +465,9 @@ def thing_type_get_plays_req(label: Label):
 def thing_type_set_plays_req(label: Label, role_type: concept_proto.Type, overridden_role_type: concept_proto.Type = None):
     req = concept_proto.Type.Req()
     set_plays_req = concept_proto.ThingType.SetPlays.Req()
-    set_plays_req.role.CopyFrom(role_type)
+    set_plays_req.role_type.CopyFrom(role_type)
     if overridden_role_type:
-        set_plays_req.overridden_role.CopyFrom(overridden_role_type)
+        set_plays_req.overridden_type.CopyFrom(overridden_role_type)
     req.thing_type_set_plays_req.CopyFrom(set_plays_req)
     return type_req(req, label)
 
@@ -475,7 +475,7 @@ def thing_type_set_plays_req(label: Label, role_type: concept_proto.Type, overri
 def thing_type_unset_plays_req(label: Label, role_type: concept_proto.Type):
     req = concept_proto.Type.Req()
     unset_plays_req = concept_proto.ThingType.UnsetPlays.Req()
-    unset_plays_req.role.CopyFrom(role_type)
+    unset_plays_req.role_type.CopyFrom(role_type)
     req.thing_type_unset_plays_req.CopyFrom(unset_plays_req)
     return type_req(req, label)
 

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -595,8 +595,8 @@ def relation_type_get_relates_overridden_req(label: Label, role_label: str):
     req = concept_proto.Type.Req()
     get_relates_overridden_req = concept_proto.RelationType.GetRelatesOverridden.Req()
     get_relates_overridden_req.label = role_label
-    req.relation_type_gets_relates_overridden.CopyFrom(get_relates_overridden_req)
-    return req(req, label)
+    req.relation_type_get_relates_overridden_req.CopyFrom(get_relates_overridden_req)
+    return type_req(req, label)
 
 
 def relation_type_set_relates_req(label: Label, role_label: str, overridden_label: str = None):

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -525,7 +525,7 @@ def thing_type_get_owns_explicit_req(label: Label, value_type: concept_proto.Att
 def thing_type_get_owns_overridden_req(label: Label, attribute_type: concept_proto.Type):
     req = concept_proto.Type.Req()
     get_owns_overridden_req = concept_proto.ThingType.GetOwnsOverridden.Req()
-    get_owns_overridden_req.attribute_type = attribute_type
+    get_owns_overridden_req.attribute_type.CopyFrom(attribute_type)
     req.thing_type_get_owns_overridden_req.CopyFrom(get_owns_overridden_req)
     return type_req(req, label)
 

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -595,7 +595,7 @@ def relation_type_get_relates_overridden_req(label: Label, role_label: str):
     req = concept_proto.Type.Req()
     get_relates_overridden_req = concept_proto.RelationType.GetRelatesOverridden.Req()
     get_relates_overridden_req.label = role_label
-    req.relation_type_gets_relates_overridden_req.CopyFrom(get_relates_overridden_req)
+    req.relation_type_gets_relates_overridden.CopyFrom(get_relates_overridden_req)
     return req(req, label)
 
 

--- a/typedb/concept/type/attribute_type.py
+++ b/typedb/concept/type/attribute_type.py
@@ -31,7 +31,8 @@ from typedb.api.concept.type.attribute_type import AttributeType, RemoteAttribut
 from typedb.common.exception import TypeDBClientException, INVALID_CONCEPT_CASTING
 from typedb.common.label import Label
 from typedb.common.rpc.request_builder import attribute_type_get_owners_req, attribute_type_put_req, \
-    attribute_type_get_req, attribute_type_get_regex_req, attribute_type_set_regex_req
+    attribute_type_get_req, attribute_type_get_regex_req, attribute_type_set_regex_req, \
+    attribute_type_get_owners_explicit_req
 from typedb.concept.proto import concept_proto_builder, concept_proto_reader
 from typedb.concept.type.thing_type import _ThingType, _RemoteThingType
 
@@ -101,8 +102,14 @@ class _RemoteAttributeType(_RemoteThingType, RemoteAttributeType):
             return stream
 
     def get_owners(self, only_key: bool = False):
-        return (concept_proto_reader.thing_type(tt) for rp in self.stream(attribute_type_get_owners_req(self.get_label(), only_key))
+        return (concept_proto_reader.thing_type(tt)
+                for rp in self.stream(attribute_type_get_owners_req(self.get_label(), only_key))
                 for tt in rp.attribute_type_get_owners_res_part.thing_types)
+
+    def get_owners_explicit(self, only_key: bool = False):
+        return (concept_proto_reader.thing_type(tt)
+                for rp in self.stream(attribute_type_get_owners_explicit_req(self.get_label(), only_key))
+                for tt in rp.attribute_type_get_owners_explicit_res_part.thing_types)
 
     def put_internal(self, proto_value: concept_proto.Attribute.Value):
         res = self.execute(attribute_type_put_req(self.get_label(), proto_value)).attribute_type_put_res

--- a/typedb/concept/type/attribute_type.py
+++ b/typedb/concept/type/attribute_type.py
@@ -102,7 +102,7 @@ class _RemoteAttributeType(_RemoteThingType, RemoteAttributeType):
 
     def get_owners(self, only_key: bool = False):
         return (concept_proto_reader.thing_type(tt) for rp in self.stream(attribute_type_get_owners_req(self.get_label(), only_key))
-                for tt in rp.attribute_type_get_owners_res_part.owners)
+                for tt in rp.attribute_type_get_owners_res_part.thing_types)
 
     def put_internal(self, proto_value: concept_proto.Attribute.Value):
         res = self.execute(attribute_type_put_req(self.get_label(), proto_value)).attribute_type_put_res

--- a/typedb/concept/type/relation_type.py
+++ b/typedb/concept/type/relation_type.py
@@ -18,11 +18,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Iterator, TYPE_CHECKING, Union
 
 import typedb_protocol.common.concept_pb2 as concept_proto
 
-from typedb.api.concept.thing.relation import Relation
 from typedb.api.concept.type.relation_type import RelationType, RemoteRelationType
 from typedb.common.label import Label
 from typedb.common.rpc.request_builder import relation_type_create_req, relation_type_get_relates_req, \

--- a/typedb/concept/type/relation_type.py
+++ b/typedb/concept/type/relation_type.py
@@ -62,7 +62,7 @@ class _RemoteRelationType(_RemoteThingType, RemoteRelationType):
             return _RoleType.of(res.role_type) if res.HasField("role_type") else None
         else:
             return (_RoleType.of(rt) for rp in self.stream(relation_type_get_relates_req(self.get_label()))
-                    for rt in rp.relation_type_get_relates_res_part.roles)
+                    for rt in rp.relation_type_get_relates_res_part.role_types)
 
     def set_relates(self, role_label: str, overridden_label: str = None):
         self.execute(relation_type_set_relates_req(self.get_label(), role_label, overridden_label))

--- a/typedb/concept/type/thing_type.py
+++ b/typedb/concept/type/thing_type.py
@@ -65,7 +65,8 @@ class _RemoteThingType(_RemoteType, RemoteThingType):
         self.execute(thing_type_unset_abstract_req(self.get_label()))
 
     def set_plays(self, role_type: RoleType, overridden_role_type: RoleType = None):
-        self.execute(thing_type_set_plays_req(self.get_label(), concept_proto_builder.role_type(role_type), concept_proto_builder.role_type(overridden_role_type)))
+        self.execute(thing_type_set_plays_req(self.get_label(), concept_proto_builder.role_type(role_type),
+                                              concept_proto_builder.role_type(overridden_role_type)))
 
     def unset_plays(self, role_type: RoleType):
         self.execute(thing_type_unset_plays_req(self.get_label(), concept_proto_builder.role_type(role_type)))
@@ -80,24 +81,27 @@ class _RemoteThingType(_RemoteType, RemoteThingType):
 
     def get_plays_overridden(self, role_type: "RoleType"):
         res = self.execute(thing_type_get_plays_overridden(
-            self.get_label(),concept_proto_builder.role_type(role_type)
+            self.get_label(), concept_proto_builder.role_type(role_type)
         )).thing_type_get_plays_overridden_res
         return concept_proto_reader.type_(res.role_type) if res.HasField("role_type") else None
 
     def set_owns(self, attribute_type: AttributeType, overridden_type: AttributeType = None, is_key: bool = False):
-        self.execute(thing_type_set_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type), concept_proto_builder.thing_type(overridden_type), is_key))
+        self.execute(thing_type_set_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type),
+                                             concept_proto_builder.thing_type(overridden_type), is_key))
 
     def unset_owns(self, attribute_type: AttributeType):
         self.execute(thing_type_unset_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type)))
 
     def get_owns(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
         return (concept_proto_reader.type_(t)
-                for rp in self.stream(thing_type_get_owns_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
+                for rp in self.stream(
+            thing_type_get_owns_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
                 for t in rp.thing_type_get_owns_res_part.attribute_types)
 
     def get_owns_explicit(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
         return (concept_proto_reader.type_(t)
-                for rp in self.stream(thing_type_get_owns_explicit_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
+                for rp in self.stream(
+            thing_type_get_owns_explicit_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
                 for t in rp.thing_type_get_owns_explicit_res_part.attribute_types)
 
     def get_owns_overridden(self, attribute_type: "AttributeType"):

--- a/typedb/concept/type/thing_type.py
+++ b/typedb/concept/type/thing_type.py
@@ -72,7 +72,7 @@ class _RemoteThingType(_RemoteType, RemoteThingType):
 
     def get_plays(self):
         return (concept_proto_reader.type_(t) for rp in self.stream(thing_type_get_plays_req(self.get_label()))
-                for t in rp.thing_type_get_plays_res_part.roles)
+                for t in rp.thing_type_get_plays_res_part.role_types)
 
     def get_owns(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
         return (concept_proto_reader.type_(t) for rp in self.stream(thing_type_get_owns_req(self.get_label(), value_type.proto() if value_type else None, keys_only))

--- a/typedb/concept/type/thing_type.py
+++ b/typedb/concept/type/thing_type.py
@@ -26,7 +26,9 @@ from typedb.api.concept.type.thing_type import ThingType, RemoteThingType
 from typedb.common.label import Label
 from typedb.common.rpc.request_builder import thing_type_set_supertype_req, thing_type_get_instances_req, \
     thing_type_set_abstract_req, thing_type_unset_abstract_req, thing_type_set_plays_req, thing_type_set_owns_req, \
-    thing_type_get_plays_req, thing_type_get_owns_req, thing_type_unset_plays_req, thing_type_unset_owns_req
+    thing_type_get_plays_req, thing_type_get_owns_req, thing_type_unset_plays_req, thing_type_unset_owns_req, \
+    thing_type_get_owns_explicit_req, thing_type_get_owns_overridden_req, thing_type_get_plays_explicit_req, \
+    thing_type_get_plays_overridden
 from typedb.concept.proto import concept_proto_builder, concept_proto_reader
 from typedb.concept.type.type import _Type, _RemoteType
 
@@ -67,19 +69,41 @@ class _RemoteThingType(_RemoteType, RemoteThingType):
     def set_plays(self, role_type: RoleType, overridden_role_type: RoleType = None):
         self.execute(thing_type_set_plays_req(self.get_label(), concept_proto_builder.role_type(role_type), concept_proto_builder.role_type(overridden_role_type)))
 
-    def set_owns(self, attribute_type: AttributeType, overridden_type: AttributeType = None, is_key: bool = False):
-        self.execute(thing_type_set_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type), concept_proto_builder.thing_type(overridden_type), is_key))
+    def unset_plays(self, role_type: RoleType):
+        self.execute(thing_type_unset_plays_req(self.get_label(), concept_proto_builder.role_type(role_type)))
 
     def get_plays(self):
         return (concept_proto_reader.type_(t) for rp in self.stream(thing_type_get_plays_req(self.get_label()))
                 for t in rp.thing_type_get_plays_res_part.role_types)
 
-    def get_owns(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
-        return (concept_proto_reader.type_(t) for rp in self.stream(thing_type_get_owns_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
-                for t in rp.thing_type_get_owns_res_part.attribute_types)
+    def get_plays_explicit(self):
+        return (concept_proto_reader.type_(t) for rp in self.stream(thing_type_get_plays_explicit_req(self.get_label()))
+                for t in rp.thing_type_get_plays_explicit_res_part.role_types)
 
-    def unset_plays(self, role_type: RoleType):
-        self.execute(thing_type_unset_plays_req(self.get_label(), concept_proto_builder.role_type(role_type)))
+    def get_plays_overridden(self, role_type: "RoleType"):
+        res = self.execute(thing_type_get_plays_overridden(
+            self.get_label(),concept_proto_builder.role_type(role_type)
+        )).thing_type_get_plays_overridden_res
+        return concept_proto_reader.type_(res.role_type) if res.HasField("role_type") else None
+
+    def set_owns(self, attribute_type: AttributeType, overridden_type: AttributeType = None, is_key: bool = False):
+        self.execute(thing_type_set_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type), concept_proto_builder.thing_type(overridden_type), is_key))
 
     def unset_owns(self, attribute_type: AttributeType):
         self.execute(thing_type_unset_owns_req(self.get_label(), concept_proto_builder.thing_type(attribute_type)))
+
+    def get_owns(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
+        return (concept_proto_reader.type_(t)
+                for rp in self.stream(thing_type_get_owns_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
+                for t in rp.thing_type_get_owns_res_part.attribute_types)
+
+    def get_owns_explicit(self, value_type: AttributeType.ValueType = None, keys_only: bool = False):
+        return (concept_proto_reader.type_(t)
+                for rp in self.stream(thing_type_get_owns_explicit_req(self.get_label(), value_type.proto() if value_type else None, keys_only))
+                for t in rp.thing_type_get_owns_explicit_res_part.attribute_types)
+
+    def get_owns_overridden(self, attribute_type: "AttributeType"):
+        res = self.execute(thing_type_get_owns_overridden_req(
+            self.get_label(), concept_proto_builder.thing_type(attribute_type)
+        )).thing_type_get_owns_overridden_res
+        return concept_proto_reader.attribute_type(res.attribute_type) if res.HasField("attribute_type") else None

--- a/typedb/concept/type/thing_type.py
+++ b/typedb/concept/type/thing_type.py
@@ -18,12 +18,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Iterator
 
 from typedb.api.concept.type.attribute_type import AttributeType
 from typedb.api.concept.type.role_type import RoleType
 from typedb.api.concept.type.thing_type import ThingType, RemoteThingType
-from typedb.common.label import Label
 from typedb.common.rpc.request_builder import thing_type_set_supertype_req, thing_type_get_instances_req, \
     thing_type_set_abstract_req, thing_type_unset_abstract_req, thing_type_set_plays_req, thing_type_set_owns_req, \
     thing_type_get_plays_req, thing_type_get_owns_req, thing_type_unset_plays_req, thing_type_unset_owns_req, \


### PR DESCRIPTION
## What is the goal of this PR?

We catch up client-nodejs with the Java client version 2.9.0, which exposes an extended set of APIs on `Type`s.
We implement:
* `ThingType.get_owns_explicit()` and `ThingType.get_owns_overridden`
* `AttributeType.get_owners_explicit()`
* `ThingType.get_plays_explicit()`
* `ThingType.get_plays_overridden()`
* `RelationType.get_relates_explicit()` and `RelationType.get_relates_overridden()`

## What are the changes implemented in this PR?

* Update `typedb-protocol` to version 2.9.0, and synchronise the naming conventions that were updated
* Implement Concept `Type` APIs that were missing, matching the requirements released in client-java 2.9.0
* Update any required changes in the lower-level packges to build requests
* Disambiguate clashing behaviour steps by adding type hints to them
