### PR TITLE
Remove deprecated pip repositories Bazel call

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,8 +46,6 @@ kt_register_toolchains()
 # Load //builder/python
 load("@vaticle_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
-load("@rules_python//python:pip.bzl", "pip_repositories")
-pip_repositories()
 
 # Load //builder/grpc
 load("@vaticle_dependencies//builder/grpc:deps.bzl", grpc_deps = "deps")


### PR DESCRIPTION
## What is the goal of this PR?

We remove an unneccessary call of `pip_repositories` despite it being a deprecated function from `rules_python`, including in our own patched version. Additionally, this cleans up our bazel command output. See the output message below.

```
DEBUG: /private/var/tmp/[...]/external/rules_python/python/pip.bzl:228:10: 
DEPRECATED: the pip_repositories rule has been replaced with pip_install, please see rules_python 0.1 release notes
```

See this dependencies PR for more information:
- https://github.com/vaticle/dependencies/pull/372

## What are the changes implemented in this PR?

We remove the command that loads the function as well as the call to the function.
