### PR TITLE
Bump protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 typedb-protocol==2.12.0
-grpcio==1.43.0
-protobuf==3.20.1
+grpcio>=1.43.0,<=1.46.0
+protobuf>=3.15.5,<=3.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 typedb-protocol==2.12.0
 grpcio==1.43.0
-protobuf==3.15.5
+protobuf==3.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 typedb-protocol==2.12.0
-grpcio>=1.43.0,<=1.46.0
+grpcio>=1.43.0,<=1.44.0
 protobuf>=3.15.5,<=3.20.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,7 +32,7 @@
 
 typedb-protocol==2.12.0
 grpcio==1.43.0
-protobuf==3.15.5
+protobuf==3.20.1
 
 
 # Dev dependencies (not required to use the typedb-client package, but necessary for its development)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,8 +31,8 @@
 ## Dependencies
 
 typedb-protocol==2.12.0
-grpcio==1.43.0
-protobuf==3.20.1
+grpcio>=1.43.0,<=1.46.0
+protobuf>=3.15.5,<=3.20.1
 
 
 # Dev dependencies (not required to use the typedb-client package, but necessary for its development)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,7 +31,7 @@
 ## Dependencies
 
 typedb-protocol==2.12.0
-grpcio>=1.43.0,<=1.46.0
+grpcio>=1.43.0,<=1.44.0
 protobuf>=3.15.5,<=3.20.1
 
 


### PR DESCRIPTION
## What is the goal of this PR?

We've bumped our protobuf dependency in response to the following issue:
- https://github.com/vaticle/typedb-client-python/issues/270

## What are the changes implemented in this PR?

We've changed our pinned protobuf version from 3.15.5 to 3.20.1.
