### PR TITLE
Depend on grpcio<2, protobuf<4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 typedb-protocol==2.12.0
-grpcio>=1.43.0,<=1.44.0
-protobuf>=3.15.5,<=3.20.1
+grpcio>=1.43.0,<2
+protobuf>=3.15.5,<4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,8 +31,8 @@
 ## Dependencies
 
 typedb-protocol==2.12.0
-grpcio>=1.43.0,<=1.44.0
-protobuf>=3.15.5,<=3.20.1
+grpcio>=1.43.0,<2
+protobuf>=3.15.5,<4
 
 
 # Dev dependencies (not required to use the typedb-client package, but necessary for its development)


### PR DESCRIPTION
## What is the goal of this PR?

We increased the flexibility of our dependency requirements. Any version of `grpcio < 2` and `protobuf < 4` are now acceptable.

## What are the changes implemented in this PR?

We have previously had to do a new release of this client whenever someone depends on a different version of `grpcio` or `protobuf` in their project - in particular, even if they are depending on a _newer_ version. This is not a good experience for developers.

Now, we accept any version that is _expected_ to be non-breaking.