### PR TITLE
Remove unnecessary delays before closing sessions and clients in tests

### DIFF
--- a/tests/behaviour/background/environment_base.py
+++ b/tests/behaviour/background/environment_base.py
@@ -18,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import time
-
 from behave.model_core import Status
 from typedb.client import *
 

--- a/tests/behaviour/background/environment_base.py
+++ b/tests/behaviour/background/environment_base.py
@@ -77,9 +77,6 @@ def after_scenario(context: Context, scenario):
     if scenario.status == Status.skipped:
         return
 
-    #TODO: REMOVE THIS ONCE THE CRASHES ARE FIXED
-    time.sleep(0.01)
-
     for session in context.sessions:
         session.close()
     for future_session in context.sessions_parallel:
@@ -89,7 +86,4 @@ def after_scenario(context: Context, scenario):
 
 
 def after_all(context: Context):
-    #TODO: REMOVE THIS ONCE THE CRASHES ARE FIXED
-    time.sleep(0.01)
-
     context.client.close()


### PR DESCRIPTION
## What is the goal of this PR?

We clean up the delays that were introduced as a workaround to a segmentation fault in a much older version of Grakn. Current versions of TypeDB don't exhibit the faulty behaviour.

## What are the changes implemented in this PR?

The delays were prompted by https://github.com/vaticle/typedb/issues/6135, which appears to have been resolved.