### PR TITLE
Fix duplicate requirements specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,11 @@
 # under the License.
 #
 
-## To install all dependencies, run: pip install -r requirements.txt
+## To install primary (not dev) dependencies, run: 
+#  pip install -r requirements.txt
+
+## To install ALL (including dev) dependencies, run:
+#  pip instal -r requirements_dev.txt
 
 
 ## Configuration options
@@ -31,7 +35,6 @@
 
 ## Dependencies
 
-# IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 typedb-protocol==2.14.1
 grpcio>=1.43.0,<2
 protobuf>=3.15.5,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@
 #  pip install -r requirements.txt
 
 ## To install ALL (including dev) dependencies, run:
-#  pip instal -r requirements_dev.txt
+#  pip install -r requirements_dev.txt
 
 
 ## Configuration options

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,20 +19,12 @@
 # under the License.
 #
 
-## To install all dependencies, run: pip install -r requirements_dev.txt
+## To install ALL dependencies, run: pip install -r requirements_dev.txt
 
 
-## Configuration options
+## Primary Dependencies
 
-# Allow importing of snapshots
---extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple
-
-
-## Dependencies
-
-typedb-protocol==2.14.1
-grpcio>=1.43.0,<2
-protobuf>=3.15.5,<4
+-r requirements.txt
 
 
 # Dev dependencies (not required to use the typedb-client package, but necessary for its development)


### PR DESCRIPTION
## What is the goal of this PR?

This PR solves issue #219 by including `requirements.txt` inside of `requirements_dev.txt`, so that the requirements are no longer duplicated. Going forward, developers will no longer need to remember to copy changes from `requirements.txt` to `requirements_dev.txt`.

## What are the changes implemented in this PR?

This PR adds a reference (`-r requirements.txt`) to `requirements_dev.txt`, and cleans up the instructions around it. See the [pip install Requirements File Format](https://pip.pypa.io/en/stable/reference/requirements-file-format/) for details on this feature.

closes #219 
