### PR TITLE
Cluster password policy and user management support

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -40,6 +40,11 @@ build:
       image: vaticle-ubuntu-22.04
       type: foreground
       command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r requirements_dev.txt
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "886896328b598a2e89e0ac149ac50a6af43dd49b",
+        tag = "2.16.1",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ff021f6201db41c1f81af1dfec5c90b8b9803efe",
+        tag = "2.16.1",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.14.3",
+        commit = "886896328b598a2e89e0ac149ac50a6af43dd49b",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        tag = "2.13.0",
+        commit = "ff021f6201db41c1f81af1dfec5c90b8b9803efe",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,6 @@
 
 ## Dependencies
 
-typedb-protocol==2.14.1
+typedb-protocol==0.0.0-22c0704c893f362053cc88e68ee2e113384dc03f
 grpcio>=1.43.0,<2
 protobuf>=3.15.5,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,6 @@
 
 ## Dependencies
 
-typedb-protocol==0.0.0-22c0704c893f362053cc88e68ee2e113384dc03f
+typedb-protocol==2.16.1
 grpcio>=1.43.0,<2
 protobuf>=3.15.5,<4

--- a/tests/behaviour/connection/user/user_steps.py
+++ b/tests/behaviour/connection/user/user_steps.py
@@ -48,9 +48,19 @@ def step_impl(context: Context, username: str, password: str):
     _get_client(context).users().create(username, password)
 
 
-@step("user password: {username}, {password}")
+@step("users delete: {username}")
+def step_impl(context: Context, username: str):
+    _get_client(context).users().delete(username)
+
+
+@step("users password set: {username}, {password}")
 def step_impl(context: Context, username: str, password: str):
-    _get_client(context).users().get(username).password(password)
+    _get_client(context).users().password_set(username, password)
+
+
+@step("users password update: {username}, {password_old}, {password_new}")
+def step_impl(context: Context, username: str, password_old: str, password_new: str):
+    _get_client(context).users().get(username).password_update(password_old, password_new)
 
 
 @step("user connect: {username}, {password}")
@@ -59,9 +69,3 @@ def step_impl(context: Context, username: str, password: str):
     credential = TypeDBCredential(username, password, root_ca_path)
     with TypeDB.cluster_client(addresses=["127.0.0.1:" + context.config.userdata["port"]], credential=credential) as client:
         client.databases().all()
-
-
-@step("user delete: {username}")
-def step_impl(context: Context, username: str):
-    user = _get_client(context).users().get(username)
-    user.delete()

--- a/typedb/api/connection/user.py
+++ b/typedb/api/connection/user.py
@@ -20,7 +20,7 @@
 #
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 
 class User(ABC):
@@ -30,19 +30,15 @@ class User(ABC):
         pass
 
     @abstractmethod
-    def password(self, password: str) -> None:
+    def password_expiry_days(self) -> Optional[int]:
         pass
 
     @abstractmethod
-    def delete(self) -> None:
+    def password_update(self, password_old: str, password_new: str) -> None:
         pass
 
 
 class UserManager(ABC):
-
-    @abstractmethod
-    def get(self, username: str) -> User:
-        pass
 
     @abstractmethod
     def contains(self, username: str) -> bool:
@@ -53,5 +49,17 @@ class UserManager(ABC):
         pass
 
     @abstractmethod
+    def delete(self, username: str) -> None:
+        pass
+
+    @abstractmethod
+    def get(self, username: str) -> User:
+        pass
+
+    @abstractmethod
     def all(self) -> List[User]:
+        pass
+
+    @abstractmethod
+    def password_set(self, username: str, password: str) -> None:
         pass

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -100,29 +100,43 @@ def cluster_user_manager_create_req(username: str, password: str):
     return req
 
 
+def cluster_user_manager_delete_req(username: str):
+    req = cluster_user_proto.ClusterUserManager.Delete.Req()
+    req.username = username
+    return req
+
+
 def cluster_user_manager_contains_req(username: str):
     req = cluster_user_proto.ClusterUserManager.Contains.Req()
     req.username = username
     return req
 
 
-# ClusterUser
-
-def cluster_user_password_req(username: str, password: str):
-    req = cluster_user_proto.ClusterUser.Password.Req()
+def cluster_user_manager_password_set_req(username: str, password: str):
+    req = cluster_user_proto.ClusterUserManager.PasswordSet.Req()
     req.username = username
     req.password = password
     return req
 
 
-def cluster_user_token_req(username: str):
-    req = cluster_user_proto.ClusterUser.Token.Req()
+def cluster_user_manager_get_req(username: str):
+    req = cluster_user_proto.ClusterUserManager.Get.Req()
     req.username = username
     return req
 
 
-def cluster_user_delete_req(username: str):
-    req = cluster_user_proto.ClusterUser.Delete.Req()
+# ClusterUser
+
+def cluster_user_password_update_req(username: str, password_old: str, password_new: str):
+    req = cluster_user_proto.ClusterUser.PasswordUpdate.Req()
+    req.username = username
+    req.password_old = password_old
+    req.password_new = password_new
+    return req
+
+
+def cluster_user_token_req(username: str):
+    req = cluster_user_proto.ClusterUser.Token.Req()
     req.username = username
     return req
 

--- a/typedb/connection/cluster/stub.py
+++ b/typedb/connection/cluster/stub.py
@@ -68,11 +68,17 @@ class _ClusterServerStub(TypeDBStub):
     def users_create(self, req: cluster_user_proto.ClusterUserManager.Create.Req) -> cluster_user_proto.ClusterUserManager.Create.Res:
         return self.may_renew_token(lambda: self._cluster_stub.users_create(req))
 
-    def user_password(self, req: cluster_user_proto.ClusterUser.Delete.Req) -> cluster_user_proto.ClusterUser.Delete.Res:
-        return self.may_renew_token(lambda: self._cluster_stub.user_password(req))
+    def users_delete(self, req: cluster_user_proto.ClusterUserManager.Delete.Req) -> cluster_user_proto.ClusterUserManager.Delete.Res:
+        return self.may_renew_token(lambda: self._cluster_stub.users_delete(req))
 
-    def user_delete(self, req: cluster_user_proto.ClusterUser.Delete.Req) -> cluster_user_proto.ClusterUser.Delete.Res:
-        return self.may_renew_token(lambda: self._cluster_stub.user_delete(req))
+    def users_password_set(self, req: cluster_user_proto.ClusterUserManager.PasswordSet.Req) -> cluster_user_proto.ClusterUserManager.PasswordSet.Res:
+        return self.may_renew_token(lambda: self._cluster_stub.users_password_set(req))
+
+    def users_get(self, req: cluster_user_proto.ClusterUserManager.Get.Req) -> cluster_user_proto.ClusterUserManager.Get.Res:
+        return self.may_renew_token(lambda: self._cluster_stub.users_get(req))
+
+    def user_password_update(self, req: cluster_user_proto.ClusterUser.PasswordUpdate.Req) -> cluster_user_proto.ClusterUser.PasswordUpdate.Res:
+        return self.may_renew_token(lambda: self._cluster_stub.user_password_update(req))
 
     def cluster_databases_all(self, req: cluster_database_proto.ClusterDatabaseManager.All.Req) -> cluster_database_proto.ClusterDatabaseManager.All.Res:
         return self.may_renew_token(lambda: self._cluster_stub.databases_all(req))


### PR DESCRIPTION
## What is the goal of this PR?

Add functionality relevant to the changes made in https://github.com/vaticle/typedb-cluster/pull/456:
* Optional password expiry in days for each user.
* The ability for admins to set passwords of other users
* User password update, which requires old and new password

## What are the changes implemented in this PR?

We've added the functionality that is being added in a recent TypeDB Cluster pull request:
* Support updating password now requiring both the old and the new password.
* Add support for retrieving the user password expiry in days. This is optional, depending on whether password expiration is enabled on the server.
* Allow updating password as the admin requiring only a new password.

