### PR TITLE
JSON serialization fixes

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -38,6 +38,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "ab05f18809252674c9b75364a9815c1b264a8b5c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "ff4f58b4db2200b907c60b28a2b8ee661449e9c0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -38,6 +38,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "46619244d5f1773505eeacf6d5bd0ae71781f8e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "ab05f18809252674c9b75364a9815c1b264a8b5c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/tests/behaviour/concept/serialization/json/BUILD
+++ b/tests/behaviour/concept/serialization/json/BUILD
@@ -20,7 +20,39 @@
 #
 
 package(default_visibility = ["//tests/behaviour:__subpackages__"])
+load("//tools:behave_rule.bzl", "typedb_behaviour_py_test")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+py_library(
+    name = "steps",
+    srcs = ["json_steps.py"],
+    deps = [],
+)
+
+typedb_behaviour_py_test(
+    name = "test",
+    feats = ["@vaticle_typedb_behaviour//concept/serialization:json.feature"],
+    background_core = ["//tests/behaviour/background:core"],
+    background_cluster = ["//tests/behaviour/background:cluster"],
+    steps = [
+        ":steps",
+        "//tests/behaviour/typeql:steps",
+        "//tests/behaviour/connection:steps",
+        "//tests/behaviour/connection/database:steps",
+        "//tests/behaviour/connection/session:steps",
+        "//tests/behaviour/connection/transaction:steps",
+    ],
+    deps = [
+        "//:client_python",
+        "//tests/behaviour:context",
+        "//tests/behaviour/util:util",
+        "//tests/behaviour/config:parameters",
+        "//tests/behaviour/background",
+    ],
+    native_typedb_artifact = "//tests:native-typedb-artifact",
+    native_typedb_cluster_artifact = "//tests:native-typedb-cluster-artifact",
+    size = "medium",
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/tests/behaviour/concept/serialization/json/json_steps.py
+++ b/tests/behaviour/concept/serialization/json/json_steps.py
@@ -48,8 +48,8 @@ def unordered_equal_to(expected: List[T]) -> UnorderedEqualTo[T]:
     return UnorderedEqualTo(expected)
 
 
-@step("JSON of answer concepts matches")
+@step("JSON serialization of answers matches")
 def step_impl(context: Context):
     expected = json.loads(context.text)
-    actual = [answer.json() for answer in context.answers]
+    actual = [answer.to_json() for answer in context.answers]
     assert_that(actual, unordered_equal_to(expected))

--- a/typedb/api/answer/concept_map.py
+++ b/typedb/api/answer/concept_map.py
@@ -42,9 +42,9 @@ class ConceptMap(ABC):
     def explainables(self) -> "ConceptMap.Explainables":
         pass
 
-    def json(self) -> Mapping[str, Mapping[str, Union[str, int, float, bool]]]:
+    def to_json(self) -> Mapping[str, Mapping[str, Union[str, int, float, bool]]]:
         return {
-            var: concept.json()
+            var: concept.to_json()
             for var, concept in self._map.items()
         }
 

--- a/typedb/api/concept/concept.py
+++ b/typedb/api/concept/concept.py
@@ -108,7 +108,7 @@ class Concept(ABC):
         pass
 
     @abstractmethod
-    def json(self) -> Mapping[str, Union[str, int, float, bool]]:
+    def to_json(self) -> Mapping[str, Union[str, int, float, bool]]:
         pass
 
 

--- a/typedb/api/concept/thing/attribute.py
+++ b/typedb/api/concept/thing/attribute.py
@@ -62,7 +62,7 @@ class Attribute(Thing, ABC):
     def as_remote(self, transaction: "TypeDBTransaction") -> "RemoteAttribute":
         pass
 
-    def json(self) -> Mapping[str, Union[str, int, float, bool]]:
+    def to_json(self) -> Mapping[str, Union[str, int, float, bool]]:
         return {
             "type": self.get_type().get_label().name(),
             "value_type": str(self.get_type().get_value_type()),
@@ -182,7 +182,7 @@ class DateTimeAttribute(Attribute, ABC):
     def as_remote(self, transaction: "TypeDBTransaction") -> "RemoteDateTimeAttribute":
         pass
 
-    def json(self) -> Mapping[str, Union[str, int, float, bool]]:
+    def to_json(self) -> Mapping[str, Union[str, int, float, bool]]:
         return {
             "type": self.get_type().get_label().name(),
             "value_type": str(self.get_type().get_value_type()),

--- a/typedb/api/concept/thing/thing.py
+++ b/typedb/api/concept/thing/thing.py
@@ -52,7 +52,7 @@ class Thing(Concept, ABC):
     def as_remote(self, transaction: "TypeDBTransaction") -> "RemoteThing":
         pass
 
-    def json(self) -> Mapping[str, str]:
+    def to_json(self) -> Mapping[str, str]:
         return {"type": self.get_type().get_label().name()}
 
 

--- a/typedb/api/concept/type/type.py
+++ b/typedb/api/concept/type/type.py
@@ -49,7 +49,7 @@ class Type(Concept, ABC):
     def as_remote(self, transaction: "TypeDBTransaction") -> "RemoteType":
         pass
 
-    def json(self) -> Mapping[str, str]:
+    def to_json(self) -> Mapping[str, str]:
         return {"label": self.get_label().scoped_name()}
 
 


### PR DESCRIPTION
## What is the goal of this PR?

We update serialization API from `json()` to more canonical `to_json()` and update the BDD test steps to reflect the changes in typedb-behaviour (https://github.com/vaticle/typedb-behaviour/pull/240).