### PR TITLE
Fix Factory Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeDB Client for Python
 
-[![Grabl](https://grabl.io/api/status/vaticle/typedb-client-python/badge.svg)](https://grabl.io/vaticle/typedb)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-client-python/badge.svg)](https://factory.vaticle.com/vaticle/typedb-client-python)
 [![GitHub release](https://img.shields.io/github/release/vaticle/typedb-client-python.svg)](https://github.com/vaticle/typedb/releases/latest)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)


### PR DESCRIPTION
## What is the goal of this PR?

We've updated the Factory badge from the old 'Grabl' badge that is no longer active.

## What are the changes implemented in this PR?

Updated embedded badge link and URL in the README. 